### PR TITLE
[#358] partition components interops

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,11 +41,8 @@
         // TODO(Guss): test matrix
         // csl::ensure
         "CSL_ENSURE__ENABLE_IOSTREAM_SUPPORT": true,
-        "CSL_ENSURE__ENABLE_FMT_SUPPORT": true,
-        // csl::ag
-        // "CSL_AG__ENABLE_IOSTREAM_SUPPORT": true,
-        // "CSL_AG__ENABLE_FMTLIB_SUPPORT": true,
-        // "CSL_AG__ENABLE_STD_FORMAT_SUPPORT": true
+        "CSL_ENSURE__ENABLE_FMT_SUPPORT": true
+        // csl::ag formatting opt-ins are feature headers (csl/ag/formatting/*.hpp), not macros
     },
     "cmake.options.statusBarVisibility": "compact",
     "[cpp][c]": {

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ See project's
 
     ```cpp
     #include <csl/ag.hpp>
-    #include <csl/ag/formatting/fmt.hpp> // opt-in: fmt::formatter support for aggregates
+    #include <csl/ag/formatting/backend/fmt.hpp> // opt-in: fmt::formatter support for aggregates
     ```
 
     ⚠️ A feature header adds blanket specializations to the entities `<csl/ag.hpp>` declares, so the usual
@@ -349,10 +349,10 @@ See live [demonstration here](https://godbolt.org/z/sxbvjGj4K).
 
 ```cpp
 #include <csl/typeinfo.hpp>
-#include <csl/cxx20/ensure.hpp>           // with CSL_ENSURE__ENABLE_STD_FORMAT_SUPPORT enabled from CMake cache
+#include <csl/cxx20/ensure.hpp>                     // with CSL_ENSURE__ENABLE_STD_FORMAT_SUPPORT enabled from CMake cache
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
-#include <csl/ag/formatting/typeinfo.hpp> // opt-in: compile-time type names for `typenamed`
+#include <csl/ag/formatting/backend/std_format.hpp> // opt-in: std::formatter support
+#include <csl/ag/formatting/typeinfo.hpp>           // opt-in: compile-time type names for `typenamed`
 
 #include <print>
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A personal incubator for library ideas and experiments, and perhaps a hint of se
 - Some libraries gain **optional enhancements** when another `csl` library is available  
   (e.g. `ag`'s `typenamed` formatting option uses `typeinfo` for compile-time type names).
 
-Such integrations are always **soft** - detected via `__has_include` with a fallback - and **never a hard CMake link** between `csl` components (a component that links a sibling in its interface fails at configure time). This keeps every component's package independent as interops grow.  
+Such integrations are always **soft** - an explicit opt-in **feature header** with a standalone fallback (e.g. `<csl/ag/formatting/typeinfo.hpp>`) - and **never a hard CMake link** between `csl` components (a component that links a sibling in its interface fails at configure time). This keeps every component's package independent as interops grow.  
 Each consuming library is responsible for testing both states itself - with and without the enhancement - self-contained in its own build files.  
 Note that enabling such tests may implicitly enable libraries you did not select.
 
@@ -191,13 +191,9 @@ See project's
 
     💡 The installed package is **dependency-free**: it never ships nor declares third-party libraries.
 
-    Optional enhancements that rely on a third party (e.g. `fmt`) are a source/consumer-time opt-in: enable the feature and provide the dependency in your own build.  
-    Enabling such an opt-in when building `csl` itself (e.g. `-DCSL_AG__ENABLE_FMTLIB_SUPPORT=ON`) affects only `csl`'s own tests and examples:
-    the macro and its third-party link are build-tree-only (`$<BUILD_INTERFACE:>`) and are stripped from the installed/exported target, so the package stays neutral.
-    A component whose interface would still leak an external package into the install is rejected at configure time.
-
-    Because such enhancements are gated by a preprocessor macro in the header, they stay fully available from the installed package: 
-    the consumer provides the dependency and defines the macro in its own build.  
+    Optional enhancements that rely on a third party (e.g. `fmt`) are a source/consumer-time opt-in,
+    materialized as **feature headers** (like fmt's own `<fmt/ranges.h>`): opt-in = `#include`, no macro, no CMake option.  
+    The consumer provides the third-party dependency in its own build - so they stay fully available from the installed package.
 
     For example, to enable `csl::ag`'s `fmt` formatting support:
 
@@ -205,33 +201,28 @@ See project's
     find_package(csl REQUIRED COMPONENTS ag)
     find_package(fmt REQUIRED)                 # consumer provides fmt
     target_link_libraries(app PRIVATE csl::ag fmt::fmt)
-    target_compile_definitions(app PRIVATE CSL_AG__ENABLE_FMTLIB_SUPPORT=1)
     ```
 
-    ⚠️ Such a compile-definition changes the entities `<csl/ag.hpp>` emits, so it is effectively part of the header's ABI:  
-    it must be defined **identically across every translation unit of the whole program** (One Definition Rule).  
-    The `PRIVATE` form above is correct for a single executable.
-    If several libraries in the same program consume `csl::ag`, define it uniformly for all of them
-    (e.g. an `INTERFACE` compile definition on a shared target), never `PRIVATE` on some and not others -
-    an inconsistent definition is undefined behavior (ill-formed, no diagnostic required).
+    ```cpp
+    #include <csl/ag.hpp>
+    #include <csl/ag/formatting/fmt.hpp> // opt-in: fmt::formatter support for aggregates
+    ```
 
-    The program-wide-safe form uses a small **proxy `INTERFACE` target** that carries the configuration
-    once, consumed by everything that uses `csl::ag`:
+    ⚠️ A feature header adds blanket specializations to the entities `<csl/ag.hpp>` declares, so the usual
+    fmt-style ODR contract applies: include it **consistently across every translation unit of the whole program**
+    (as with `<fmt/ranges.h>`) - never in some TUs and not in others when the same types are formatted.
+
+    The same mechanism covers **inter-component enhancements**: e.g. `csl::ag`'s `typenamed` formatting option
+    is enhanced by `csl::typeinfo` through a bridge feature header:
 
     ```cmake
-    find_package(csl REQUIRED COMPONENTS ag)
-    find_package(fmt REQUIRED)
+    find_package(csl REQUIRED COMPONENTS ag typeinfo)
+    target_link_libraries(app PRIVATE csl::ag csl::typeinfo)
+    ```
 
-    # Single source of truth for the csl::ag + fmt formatting configuration.
-    add_library(csl_ag_proxy INTERFACE)
-    target_link_libraries(csl_ag_proxy INTERFACE csl::ag fmt::fmt)
-    target_compile_definitions(csl_ag_proxy INTERFACE CSL_AG__ENABLE_FMTLIB_SUPPORT=1)
-
-    # Every library/executable consumes csl::ag *through the proxy*,
-    # so the macro is identical across the whole program (ODR-safe).
-    target_link_libraries(library_a PUBLIC  csl_ag_proxy)
-    target_link_libraries(library_b PUBLIC  csl_ag_proxy)
-    target_link_libraries(app       PRIVATE library_a library_b)
+    ```cpp
+    #include <csl/ag.hpp>
+    #include <csl/ag/formatting/typeinfo.hpp> // typenamed: compile-time, demangled type names
     ```
 
 #### CMake - options
@@ -351,14 +342,17 @@ int: 42
 
 #### All: pretty-printing
 
-`csl` offers 3 formatting support backends: `std::format`, `fmt`, and `std::ostream/cout`, each as optins `CSL_<lib>__ENABLE_<backend>_SUPPORT`.
+`csl` offers 3 formatting support backends: `std::format`, `fmt`, and `std::ostream/cout`.  
+For `csl::ag`, each is an opt-in **feature header** (`csl/ag/formatting/*.hpp`); for `csl::ensure`, an opt-in macro `CSL_ENSURE__ENABLE_<backend>_SUPPORT`.
 
 See live [demonstration here](https://godbolt.org/z/sxbvjGj4K).
 
 ```cpp
 #include <csl/typeinfo.hpp>
-#include <csl/cxx20/ensure.hpp> // with CSL_ENSURE__ENABLE_STD_FORMAT_SUPPORT enable from CMake cache
-#include <csl/ag.hpp>           // with CSL_AG__ENABLE_STD_FORMAT_SUPPORT enable from CMake cache
+#include <csl/cxx20/ensure.hpp>           // with CSL_ENSURE__ENABLE_STD_FORMAT_SUPPORT enabled from CMake cache
+#include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
+#include <csl/ag/formatting/typeinfo.hpp> // opt-in: compile-time type names for `typenamed`
 
 #include <print>
 

--- a/doc/.godbolt-manifest.json
+++ b/doc/.godbolt-manifest.json
@@ -80,7 +80,7 @@
     "url": "https://godbolt.org/z/3jrKPhT8P"
   },
   "libs/ag/examples/01_overview_demo.cpp": {
-    "sha256": "029a975bc56610342523e545f5a1f1bc443d143e262dff0b9609d2e2688a4122",
-    "url": "https://godbolt.org/z/7WKeTWsvv"
+    "sha256": "d5695922461a117ff2c87cb62566ee0665c9afa381145aeaec6e5a4c68784831",
+    "url": "https://godbolt.org/z/E6bn4cjKo"
   }
 }

--- a/doc/.godbolt-manifest.json
+++ b/doc/.godbolt-manifest.json
@@ -8,12 +8,12 @@
     "url": "https://godbolt.org/z/7WTnn9P5P"
   },
   "libs/ag/examples/19_formatting_ostream_advanced.cpp": {
-    "sha256": "ea6d85755dfbe597f818659760120f1142ac0bc2bf4e6d02362047626cbc3ad8",
-    "url": "https://godbolt.org/z/MY7PYePTd"
+    "sha256": "9287f45c10824a2cf8d3cb06e71de2786d5b3108e0024a71592306a9e865f9eb",
+    "url": "https://godbolt.org/z/xsTxxExrG"
   },
   "libs/ag/examples/18_formatting_ostream_simple.cpp": {
-    "sha256": "156309f6a6a205f7e5fe849d09ac2c7037a791ff369d1fbabfa826048d7222f4",
-    "url": "https://godbolt.org/z/Wve3j19b9"
+    "sha256": "c353c8eb9efb879eeae5caf9afdb27286ea76060dab3e8f5380ef16d0cda4987",
+    "url": "https://godbolt.org/z/4763osbv1"
   },
   "libs/ag/examples/17_for_each.cpp": {
     "sha256": "ef4dc0f22e5d0f49e187a91c50a96d492246ce889f6fa9a2b46310226a7a461e",
@@ -80,7 +80,7 @@
     "url": "https://godbolt.org/z/3jrKPhT8P"
   },
   "libs/ag/examples/01_overview_demo.cpp": {
-    "sha256": "c0f0416009c4ce13f6878d7869401e8fe90dfab841d66a13abb08f9a0fa3dadf",
-    "url": "https://godbolt.org/z/zW31zz3fh"
+    "sha256": "029a975bc56610342523e545f5a1f1bc443d143e262dff0b9609d2e2688a4122",
+    "url": "https://godbolt.org/z/7WKeTWsvv"
   }
 }

--- a/doc/.godbolt-manifest.json
+++ b/doc/.godbolt-manifest.json
@@ -8,12 +8,12 @@
     "url": "https://godbolt.org/z/7WTnn9P5P"
   },
   "libs/ag/examples/19_formatting_ostream_advanced.cpp": {
-    "sha256": "9287f45c10824a2cf8d3cb06e71de2786d5b3108e0024a71592306a9e865f9eb",
-    "url": "https://godbolt.org/z/xsTxxExrG"
+    "sha256": "22ae44d2fa9e19e3fafff5437bac6db42dc94cb364c890279a9b5ab8754a2477",
+    "url": "https://godbolt.org/z/PT8nGeKsh"
   },
   "libs/ag/examples/18_formatting_ostream_simple.cpp": {
-    "sha256": "c353c8eb9efb879eeae5caf9afdb27286ea76060dab3e8f5380ef16d0cda4987",
-    "url": "https://godbolt.org/z/4763osbv1"
+    "sha256": "911608ac7403d626cdcc18b3cb629d3bed05aa0819fdc4ece8ae96a2a78e1f1b",
+    "url": "https://godbolt.org/z/Y3jncj97T"
   },
   "libs/ag/examples/17_for_each.cpp": {
     "sha256": "ef4dc0f22e5d0f49e187a91c50a96d492246ce889f6fa9a2b46310226a7a461e",
@@ -80,7 +80,7 @@
     "url": "https://godbolt.org/z/3jrKPhT8P"
   },
   "libs/ag/examples/01_overview_demo.cpp": {
-    "sha256": "d5695922461a117ff2c87cb62566ee0665c9afa381145aeaec6e5a4c68784831",
-    "url": "https://godbolt.org/z/E6bn4cjKo"
+    "sha256": "559db7a4ffc5ff34ecd0a1cd687f9bdf6615a10daad8fd0441cfe7b4706a887d",
+    "url": "https://godbolt.org/z/xhhbh1Ycn"
   }
 }

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
 # C++ Shelf
 
-Collection of single-header, header-only C++ libraries.  
+Collection of single-header, header-only C++ libraries *(a single-header core per library, plus optional per-feature opt-in headers)*.  
 [Source on GitHub](https://github.com/GuillaumeDua/CppShelf), MIT License
 
 ---

--- a/doc/scripts/update_godbolt_links.py
+++ b/doc/scripts/update_godbolt_links.py
@@ -40,35 +40,18 @@ CE_SHORTLINK_API = 'https://godbolt.org/api/shortener'
 CE_COMPILER_ID = 'clang_trunk'
 CE_COMPILER_OPTIONS = '-std=c++23 -O2'
 
-# Maps each local CSL include to its raw GitHub URL counterpart.
-#   CE frontend supports URL-based #include, but the API itself does not
-#   so the script transforms includes pp-directives before building the session payload.
-INCLUDE_URL_MAP: dict[str, str] = {
-    'csl/ag.hpp': (
-        'https://raw.githubusercontent.com/GuillaumeDua/CppShelf'
-        '/refs/heads/main/libs/ag/includes/ag/csl/ag.hpp'
-    ),
-    'csl/mp.hpp': (
-        'https://raw.githubusercontent.com/GuillaumeDua/CppShelf'
-        '/refs/heads/main/libs/mp/includes/mp/csl/mp.hpp'
-    ),
-    'csl/ensure.hpp': (
-        'https://raw.githubusercontent.com/GuillaumeDua/CppShelf'
-        '/refs/heads/main/libs/ensure/includes/ensure/csl/ensure.hpp'
-    ),
-    'csl/functional.hpp': (
-        'https://raw.githubusercontent.com/GuillaumeDua/CppShelf'
-        '/refs/heads/main/libs/functional/includes/functional/csl/functional.hpp'
-    ),
-    'csl/typeinfo.hpp': (
-        'https://raw.githubusercontent.com/GuillaumeDua/CppShelf'
-        '/refs/heads/main/libs/typeinfo/includes/typeinfo/csl/typeinfo.hpp'
-    ),
-    'csl/wf.hpp': (
-        'https://raw.githubusercontent.com/GuillaumeDua/CppShelf'
-        '/refs/heads/main/libs/wf/includes/wf/csl/wf.hpp'
-    ),
-}
+# Maps local CSL includes to their raw GitHub URL counterparts.
+#   CE frontend supports URL-based #include, but the API itself does not,
+#   so the script transforms include pp-directives before building the session payload.
+#   Handles both single-header components and feature headers:
+#       csl/<lib>.hpp             -> libs/<lib>/includes/<lib>/csl/<lib>.hpp
+#       csl/<lib>/<feature>.hpp   -> libs/<lib>/includes/<lib>/csl/<lib>/<feature>.hpp
+#   (e.g. csl/ag/formatting/fmt.hpp -> libs/ag/includes/ag/csl/ag/formatting/fmt.hpp)
+#   NOTE: include order matters on CE: a feature header self-includes its prerequisites only
+#   when they are reachable (or already included, detected via the CSL_<LIB>__INCLUDED markers) -
+#   examples list <csl/<lib>.hpp> (and any sibling-component prerequisite) first.
+RAW_URL_BASE = 'https://raw.githubusercontent.com/GuillaumeDua/CppShelf/refs/heads/main'
+CSL_INCLUDE_RE = re.compile(r'#include <(?P<path>csl/(?P<lib>[a-z0-9_]+)(?:\.hpp|/[^>]+\.hpp))>')
 
 EXAMPLE_BLOCK_RE = re.compile(
     r'<!-- EXAMPLE_BEGIN: (?P<file>[^\s>]+) -->\n'
@@ -82,9 +65,13 @@ def sha256_of(text: str) -> str:
 
 
 def transform_includes(source: str) -> str:
-    for local, url in INCLUDE_URL_MAP.items():
-        source = source.replace(f'#include <{local}>', f'#include <{url}>')
-    return source
+    def to_url(match: re.Match) -> str:
+        lib, path = match.group('lib'), match.group('path')
+        header = REPO_ROOT / 'libs' / lib / 'includes' / lib / path
+        if not header.is_file():
+            raise RuntimeError(f'cannot map #include <{path}> to a repo header (expected {header})')
+        return f'#include <{RAW_URL_BASE}/libs/{lib}/includes/{lib}/{path}>'
+    return CSL_INCLUDE_RE.sub(to_url, source)
 
 
 def build_layout(source: str, *, compiler_id: str, compiler_options: str) -> dict:

--- a/doc/scripts/update_godbolt_links.py
+++ b/doc/scripts/update_godbolt_links.py
@@ -46,7 +46,7 @@ CE_COMPILER_OPTIONS = '-std=c++23 -O2'
 #   Handles both single-header components and feature headers:
 #       csl/<lib>.hpp             -> libs/<lib>/includes/<lib>/csl/<lib>.hpp
 #       csl/<lib>/<feature>.hpp   -> libs/<lib>/includes/<lib>/csl/<lib>/<feature>.hpp
-#   (e.g. csl/ag/formatting/fmt.hpp -> libs/ag/includes/ag/csl/ag/formatting/fmt.hpp)
+#   (e.g. csl/ag/formatting/backend/fmt.hpp -> libs/ag/includes/ag/csl/ag/formatting/backend/fmt.hpp)
 #   NOTE: include order matters on CE: a feature header self-includes its prerequisites only
 #   when they are reachable (or already included, detected via the CSL_<LIB>__INCLUDED markers) -
 #   examples list <csl/<lib>.hpp> (and any sibling-component prerequisite) first.

--- a/libs/ag/README.md
+++ b/libs/ag/README.md
@@ -30,10 +30,10 @@ The following example demonstrates some of the features which are available in `
 <!-- EXAMPLE_BEGIN: 01_overview_demo.cpp -->
 ```cpp
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
-#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
-#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
-#include <iostream> // std::print might not be available yet: use `std::cout << std::format(...)`
+#include <csl/ag/formatting/backend/std_format.hpp> // opt-in: std::formatter support
+#include <csl/typeinfo.hpp>                         // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp>           // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
+#include <iostream>                                 // std::print might not be available yet: use `std::cout << std::format(...)`
 
 struct S { char c; int i; };
 
@@ -52,15 +52,15 @@ auto main() -> int {
     constexpr auto format_options = indexed | typenamed | indented;
     std::cout << std::format("{}", value | format_options); // equivalent to std::println("{:xit}", value)
 
-    // alternative: #include <csl/ag/formatting/ostream.hpp>
+    // alternative: #include <csl/ag/formatting/backend/ostream.hpp>
     // std::cout << "value: " << format_options << value << '\n';
 
-    // alternative: #include <csl/ag/formatting/fmt.hpp>
+    // alternative: #include <csl/ag/formatting/backend/fmt.hpp>
     // fmt::println("{:xit}", value)
 }
 ```
 
-[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/E6bn4cjKo)
+[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/xhhbh1Ycn)
 <!-- EXAMPLE_END: 01_overview_demo.cpp -->
 
 Output:
@@ -122,9 +122,9 @@ The **core of this library ships as a single, standalone header**: `csl/ag.hpp` 
 
 | Feature header | Adds | Requires |
 | --- | --- | --- |
-| `csl/ag/formatting/format.hpp` | `std::formatter` support | `<format>` |
-| `csl/ag/formatting/fmt.hpp` | `fmt::formatter` support | [fmtlib](https://github.com/fmtlib/fmt), provided by the consumer |
-| `csl/ag/formatting/ostream.hpp` | `operator<<(std::ostream &, ...)` support | - |
+| `csl/ag/formatting/backend/std_format.hpp` | `std::formatter` support | `<format>` |
+| `csl/ag/formatting/backend/fmt.hpp` | `fmt::formatter` support | [fmtlib](https://github.com/fmtlib/fmt), provided by the consumer |
+| `csl/ag/formatting/backend/ostream.hpp` | `operator<<(std::ostream &, ...)` support | - |
 | `csl/ag/formatting/typeinfo.hpp` | compile-time type names for the `typenamed` formatting option | [csl::typeinfo](https://github.com/GuillaumeDua/CppShelf/blob/main/libs/typeinfo/includes/typeinfo/csl/typeinfo.hpp) |
 
 > ℹ️ Feature headers add blanket specializations: like `<fmt/ranges.h>`, include them **consistently across the whole program** (ODR).  
@@ -214,11 +214,11 @@ Formatting backends are **not CMake options**: each is an opt-in **feature heade
 (see [Getting starting](#getting-starting) for the list, and [formatting and printing](#formatting-and-printing) for complete documentation).
 
 ```cpp
-#include <csl/ag.hpp>                     // reflection + io core (options, views, operator|) - no backend
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter
-#include <csl/ag/formatting/fmt.hpp>      // opt-in: fmt::formatter (fmtlib provided by the consumer)
-#include <csl/ag/formatting/ostream.hpp>  // opt-in: operator<<(std::ostream &, ...)
-#include <csl/ag/formatting/typeinfo.hpp> // opt-in: compile-time type names for `typenamed`
+#include <csl/ag.hpp>                               // reflection + io core (options, views, operator|) - no backend
+#include <csl/ag/formatting/backend/std_format.hpp> // opt-in: std::formatter
+#include <csl/ag/formatting/backend/fmt.hpp>        // opt-in: fmt::formatter (fmtlib provided by the consumer)
+#include <csl/ag/formatting/backend/ostream.hpp>    // opt-in: operator<<(std::ostream &, ...)
+#include <csl/ag/formatting/typeinfo.hpp>           // opt-in: compile-time type names for `typenamed`
 ```
 
 Backends may coexist in one translation unit, and format-specs are composable:
@@ -784,8 +784,8 @@ Output:
 
 There are two ways to pretty-print aggregate types, each being an opt-in **feature header**:
 
-- (✅ Best) using `std::format` (`csl/ag/formatting/format.hpp`) or the `fmt` library (`csl/ag/formatting/fmt.hpp`)
-- using the C++'s legacy way : `std::ostream& operator<<(std::ostream&, T&&)` overload (`csl/ag/formatting/ostream.hpp`)
+- (✅ Best) using `std::format` (`csl/ag/formatting/backend/std_format.hpp`) or the `fmt` library (`csl/ag/formatting/backend/fmt.hpp`)
+- using the C++'s legacy way : `std::ostream& operator<<(std::ostream&, T&&)` overload (`csl/ag/formatting/backend/ostream.hpp`)
 
 Backends may coexist in the same translation unit - each one specializes a different framework's entity.  
 The `typenamed` option renders compile-time, demangled type names when `csl/ag/formatting/typeinfo.hpp` is included,
@@ -805,7 +805,7 @@ Opt-in by include:
 
 ```cpp
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/backend/std_format.hpp>
 ```
 
 This specializes `std::formatter<T>` for any `csl::ag::concepts::aggregate T` whose fields are all formattable.
@@ -889,7 +889,7 @@ Opt-in by include - same setup as `std::format` above:
 
 ```cpp
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/fmt.hpp>
+#include <csl/ag/formatting/backend/fmt.hpp>
 ```
 
 > [fmtlib](https://github.com/fmtlib/fmt) is provided **by the consumer** (e.g. `find_package(fmt)`, then link `fmt::fmt` or `fmt::fmt-header-only`): the header uses it, `csl` never acquires nor ships it.  
@@ -899,14 +899,14 @@ Opt-in by include - same setup as `std::format` above:
 
 #### using std::ostream
 
-Opt-in by include: `csl/ag/formatting/ostream.hpp` *(prefer `std::format`/`fmt` when available: `<ostream>` is heavy at compile time, and options ride `std::ios_base::iword`)*.
+Opt-in by include: `csl/ag/formatting/backend/ostream.hpp` *(prefer `std::format`/`fmt` when available: `<ostream>` is heavy at compile time, and options ride `std::ios_base::iword`)*.
 
 Simple example :
 
 <!-- EXAMPLE_BEGIN: 18_formatting_ostream_simple.cpp -->
 ```cpp
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
+#include <csl/ag/formatting/backend/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <iostream>
 
 auto main() -> int {
@@ -917,7 +917,7 @@ auto main() -> int {
 }
 ```
 
-[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/4763osbv1)
+[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/Y3jncj97T)
 <!-- EXAMPLE_END: 18_formatting_ostream_simple.cpp -->
 
 Output:
@@ -931,7 +931,7 @@ Advanced example :
 <!-- EXAMPLE_BEGIN: 19_formatting_ostream_advanced.cpp -->
 ```cpp
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
+#include <csl/ag/formatting/backend/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <array>
 #include <iostream>
 #include <string>
@@ -969,7 +969,7 @@ auto main() -> int {
 }
 ```
 
-[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/xsTxxExrG)
+[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/PT8nGeKsh)
 <!-- EXAMPLE_END: 19_formatting_ostream_advanced.cpp -->
 
 Output:

--- a/libs/ag/README.md
+++ b/libs/ag/README.md
@@ -30,7 +30,7 @@ The following example demonstrates some of the features which are available in `
 <!-- EXAMPLE_BEGIN: 01_overview_demo.cpp -->
 ```cpp
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support (+ csl::ag::io::to_string)
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
 #include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
 #include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 #include <iostream> // std::print might not be available yet: use `std::cout << std::format(...)`
@@ -60,7 +60,7 @@ auto main() -> int {
 }
 ```
 
-[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/7WKeTWsvv)
+[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/E6bn4cjKo)
 <!-- EXAMPLE_END: 01_overview_demo.cpp -->
 
 Output:
@@ -122,7 +122,7 @@ The **core of this library ships as a single, standalone header**: `csl/ag.hpp` 
 
 | Feature header | Adds | Requires |
 | --- | --- | --- |
-| `csl/ag/formatting/format.hpp` | `std::formatter` support + [`csl::ag::io::to_string`](#using-to_stringformat_options) | `<format>` |
+| `csl/ag/formatting/format.hpp` | `std::formatter` support | `<format>` |
 | `csl/ag/formatting/fmt.hpp` | `fmt::formatter` support | [fmtlib](https://github.com/fmtlib/fmt), provided by the consumer |
 | `csl/ag/formatting/ostream.hpp` | `operator<<(std::ostream &, ...)` support | - |
 | `csl/ag/formatting/typeinfo.hpp` | compile-time type names for the `typenamed` formatting option | [csl::typeinfo](https://github.com/GuillaumeDua/CppShelf/blob/main/libs/typeinfo/includes/typeinfo/csl/typeinfo.hpp) |
@@ -215,7 +215,7 @@ Formatting backends are **not CMake options**: each is an opt-in **feature heade
 
 ```cpp
 #include <csl/ag.hpp>                     // reflection + io core (options, views, operator|) - no backend
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter + csl::ag::io::to_string
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter
 #include <csl/ag/formatting/fmt.hpp>      // opt-in: fmt::formatter (fmtlib provided by the consumer)
 #include <csl/ag/formatting/ostream.hpp>  // opt-in: operator<<(std::ostream &, ...)
 #include <csl/ag/formatting/typeinfo.hpp> // opt-in: compile-time type names for `typenamed`
@@ -224,9 +224,8 @@ Formatting backends are **not CMake options**: each is an opt-in **feature heade
 Backends may coexist in one translation unit, and format-specs are composable:
 `indexed` (":x"), `indented` (":i"), and `typenamed` (":t").
 
-> ⚠️ **Migration note** *(API break)*: the `CSL_AG__ENABLE_{STD_FORMAT,FMTLIB,IOSTREAM}_SUPPORT` macros and CMake options
-> were **removed** (silently ignored if still defined). Replace each with the matching feature-header `#include` above.  
-> `csl::ag::io::to_string` is now `std::format`-backed, and ships with `csl/ag/formatting/format.hpp` only.
+> ⚠️ Each backend keeps its native formatting idiom - `std::format("{}", value)`, `fmt::format("{}", value)`, `stream << value`:
+> `csl::ag` offers no homogeneous API across backends (at least, for now).
 
 About compact vs. pretty presentations, with type names (`typenamed`):
 
@@ -783,15 +782,22 @@ Output:
 
 ### Formatting and printing
 
-There are three ways to pretty-print aggregate types, each being an opt-in **feature header**:
+There are two ways to pretty-print aggregate types, each being an opt-in **feature header**:
 
 - (✅ Best) using `std::format` (`csl/ag/formatting/format.hpp`) or the `fmt` library (`csl/ag/formatting/fmt.hpp`)
 - using the C++'s legacy way : `std::ostream& operator<<(std::ostream&, T&&)` overload (`csl/ag/formatting/ostream.hpp`)
-- using `csl::ag::io::to_string<format_options>`, `std::format`-backed (ships with `csl/ag/formatting/format.hpp`)
 
 Backends may coexist in the same translation unit - each one specializes a different framework's entity.  
 The `typenamed` option renders compile-time, demangled type names when `csl/ag/formatting/typeinfo.hpp` is included,
 and falls back to `<typeindex>` runtime names otherwise.
+
+Formatting options are reachable through two **equivalent** syntaxes:
+
+- a **format-spec letter**: `no_braces` (`:n`), `indented` (`:i`), `indexed` (`:x`), `typenamed` (`:t`) - e.g. `std::format("{:ixt}", value)`
+- a **composable view**: `value | indented | indexed | typenamed`
+
+A composed view carries its options: formatting it with a plain `"{}"` applies them - no format-spec letter required.
+Both syntaxes produce identical outputs, and can be mixed.
 
 #### using std::format
 
@@ -970,48 +976,6 @@ Output:
 
 ```text
 {{13, 0.12}, user-defined operator<<(std::ostream&, const B &), 42, "str", 'c', (true, 2), ['a', 'b', 'c']}
-```
-
-#### using `to_string<format_options>`
-
-`csl::ag::io::to_string` returns a `std::string` directly.  
-It is `std::format`-backed, and ships with `csl/ag/formatting/format.hpp`.
-
-Options are selected as a non-type template argument. Tags (`indented`, `no_braces`, `indexed`, `typenamed`) implicitly convert to `format_options` and compose via `operator|`, so they can be combined directly as the template argument - or, equivalently, via the view-based `operator|` on the value itself:
-
-```cpp
-#include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>
-
-struct point { int x; int y; };
-struct rect  { point top_left; point bottom_right; };
-
-auto main() -> int {
-    using namespace csl::ag::io;
-
-    constexpr auto r = rect{ .top_left = { 0, 0 }, .bottom_right = { 10, 5 } };
-
-    to_string(r);                     // "{{0, 0}, {10, 5}}"        (default, compact)
-    to_string<no_braces>(r);          // "{0, 0}{10, 5}"            (no outer brackets)
-    to_string<indented>(r);           // multiline, see below
-    to_string<indented | indexed>(r); // composed options, as NTTP
-    to_string(r | indented | indexed); // equivalent, view-based composition
-}
-```
-
-`to_string<indented>(r)`:
-
-```text
-{
-    {
-        0,
-        0
-    },
-    {
-        10,
-        5
-    }
-}
 ```
 
 ## Homogeneity API with tuple-likes

--- a/libs/ag/README.md
+++ b/libs/ag/README.md
@@ -29,9 +29,10 @@ The following example demonstrates some of the features which are available in `
 
 <!-- EXAMPLE_BEGIN: 01_overview_demo.cpp -->
 ```cpp
-#include <csl/typeinfo.hpp> // optional: gives csl::ag::io::typenamed clean type names (e.g. "int")
-#define CSL_AG__ENABLE_STD_FORMAT_SUPPORT 1
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support (+ csl::ag::io::to_string)
+#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 #include <iostream> // std::print might not be available yet: use `std::cout << std::format(...)`
 
 struct S { char c; int i; };
@@ -51,15 +52,15 @@ auto main() -> int {
     constexpr auto format_options = indexed | typenamed | indented;
     std::cout << std::format("{}", value | format_options); // equivalent to std::println("{:xit}", value)
 
-    // legacy alternative: CSL_AG__ENABLE_IOSTREAM_SUPPORT
+    // alternative: #include <csl/ag/formatting/ostream.hpp>
     // std::cout << "value: " << format_options << value << '\n';
 
-    // other alternative: CSL_AG__ENABLE_FMT_SUPPORT
+    // alternative: #include <csl/ag/formatting/fmt.hpp>
     // fmt::println("{:xit}", value)
 }
 ```
 
-[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/zW31zz3fh)
+[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/7WKeTWsvv)
 <!-- EXAMPLE_END: 01_overview_demo.cpp -->
 
 Output:
@@ -116,19 +117,27 @@ This library is divided in six distinct parts :
 
 ## Getting starting
 
-This library is single-header, header-only.  
-Users may use it in various ways, however [CMake](https://cmake.org/) is the promoted one for both download and configuration.
+The **core of this library ships as a single, standalone header**: `csl/ag.hpp` alone provides the full reflection API, header-only.  
+**Opt-in features are additional headers** - purely additive, opt-in = `#include` (no macro, no CMake option, no auto-detection):
 
-> ℹ️ The `typenamed` formatting option (see [formatting and printing](#formatting-and-printing)) optionally enhances itself
-> with [csl::typeinfo](https://github.com/GuillaumeDua/CppShelf/blob/main/libs/typeinfo/includes/typeinfo/csl/typeinfo.hpp)
-> for compile-time type names, detected via `__has_include`.  
-> Without it, a `<typeindex>`-based runtime (inconsistent) fallback is used instead - `ag.hpp` stays usable as a single, standalone header either way.
+| Feature header | Adds | Requires |
+| --- | --- | --- |
+| `csl/ag/formatting/format.hpp` | `std::formatter` support + [`csl::ag::io::to_string`](#using-to_stringformat_options) | `<format>` |
+| `csl/ag/formatting/fmt.hpp` | `fmt::formatter` support | [fmtlib](https://github.com/fmtlib/fmt), provided by the consumer |
+| `csl/ag/formatting/ostream.hpp` | `operator<<(std::ostream &, ...)` support | - |
+| `csl/ag/formatting/typeinfo.hpp` | compile-time type names for the `typenamed` formatting option | [csl::typeinfo](https://github.com/GuillaumeDua/CppShelf/blob/main/libs/typeinfo/includes/typeinfo/csl/typeinfo.hpp) |
+
+> ℹ️ Feature headers add blanket specializations: like `<fmt/ranges.h>`, include them **consistently across the whole program** (ODR).  
+> Without `csl/ag/formatting/typeinfo.hpp`, the `typenamed` option falls back to `<typeindex>` runtime names
+> (deterministic, implementation-defined, possibly mangled) - `ag.hpp` stays fully usable standalone either way.
+
+Users may use it in various ways, however [CMake](https://cmake.org/) is the promoted one for both download and configuration.
 
 ### Integration
 
 #### Plain download
 
-- **Fetch** [the header file](https://raw.githubusercontent.com/GuillaumeDua/CppShelf/main/libs/ag/includes/ag/csl/ag.hpp) and deal with the build yourself, or ...
+- **Fetch** [the header file](https://raw.githubusercontent.com/GuillaumeDua/CppShelf/main/libs/ag/includes/ag/csl/ag.hpp) - and optionally the [feature headers](https://github.com/GuillaumeDua/CppShelf/tree/main/libs/ag/includes/ag/csl/ag/formatting) - and deal with the build yourself, or ...
 - **Clone** the repo, or add it as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to your project.
 
 > ⚠️ Proceeding the ways enumerated above is fast & simple.  
@@ -201,68 +210,23 @@ To extend such support, edit your **CMake** cache to set `CSL_AG__MAX_SUPPORTED_
 
 > 💡 Everything related to formatting and printing lives in the `csl::ag::io` namespace.
 
-> 💡 All options in this section are opt-ins *(`OFF` by default)*, and can be combined.
-
-Supports 3 parallel backends:
-
-- `std::format`
-- `fmt`
-- `std::ostream` (e.g `std::cout`)
-
-Format-specs are composable, and include `indexed` (":x"), `indented` (":i"), and `typenamed` (":t").
+Formatting backends are **not CMake options**: each is an opt-in **feature header** - `#include` what you need
+(see [Getting starting](#getting-starting) for the list, and [formatting and printing](#formatting-and-printing) for complete documentation).
 
 ```cpp
-struct A{ int i{}; };
-struct my_aggregate{ char c = 'a'; A a = A{ .i = 13} };
-constexpr auto my_aggregate_value = my_aggregate{};
+#include <csl/ag.hpp>                     // reflection + io core (options, views, operator|) - no backend
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter + csl::ag::io::to_string
+#include <csl/ag/formatting/fmt.hpp>      // opt-in: fmt::formatter (fmtlib provided by the consumer)
+#include <csl/ag/formatting/ostream.hpp>  // opt-in: operator<<(std::ostream &, ...)
+#include <csl/ag/formatting/typeinfo.hpp> // opt-in: compile-time type names for `typenamed`
 ```
 
-- `CSL_AG__ENABLE_STD_FORMAT_SUPPORT`: add `std::formatter<csl::ag::aggregate T>`
+Backends may coexist in one translation unit, and format-specs are composable:
+`indexed` (":x"), `indented` (":i"), and `typenamed` (":t").
 
-  ```cpp
-  std::print("{}",     my_aggregate_value);                         // compact, default → {'a', {13}}
-  std::print("{:n}",   my_aggregate_value);                         // no outer brackets → 'a'{13}
-  std::print("{:xti}", my_aggregate_value);                         // format-spec letters: x=indexed, t=typenamed, i=indented
-  std::print("{}",     my_aggregate_value | csl::ag::io::indented); // pretty, multi-line → see below
-
-  using namespace csl::ag::io;
-  constexpr auto view = indexed | typenamed | indented;             // composed format_options, reusable
-  std::print("{}", my_aggregate_value | view);                      // view-based composition → same as "{:xti}"
-  ```
-
-- `CSL_AG__ENABLE_FMTLIB_SUPPORT`: makes `csl::ag` depends on the `fmt` library, and add `fmt::formatter<csl::ag::aggregate T>`.
-
-  > If [fmtlib](https://github.com/fmtlib/fmt)'s `cmake` target `fmt::fmt-header-only` is not available when building `csl::ag` with `CSL_AG__ENABLE_FMTLIB_SUPPORT` set to `ON`, then such a dependency will be injected using `cmake FetchContent`.
-
-  ```cpp
-  fmt::print("{}",     my_aggregate_value);
-  fmt::print("{:n}",   my_aggregate_value);
-  fmt::print("{:xti}", my_aggregate_value); // format-spec letters: x=indexed, t=typenamed, i=indented
-  fmt::print("{}",     my_aggregate_value | csl::ag::io::indented);
-
-  using namespace csl::ag::io;
-  constexpr auto view = indexed | typenamed | indented; // composed format_options, reusable
-  fmt::print("{}", my_aggregate_value | view);          // view-based composition → same as "{:xti}"
-  ```
-
-- `CSL_AG__ENABLE_IOSTREAM_SUPPORT`: add `csl::ag::io::operator<<(std::ostream &, csl::ag::concepts::structured_bindable auto const &)`
-
-  ```cpp
-  using namespace csl::ag::io;
-  std::cout << my_aggregate_value;              // compact, default
-  std::cout << no_braces << my_aggregate_value; // one-shot manipulator → no outer brackets
-  std::cout << (my_aggregate_value | indented); // view-based composition → pretty, multi-line
-  ```
-
-- `csl::ag::io::to_string`: available as soon as any one of the options above is enabled. Returns a `std::string` directly, with the same call syntax regardless of which backend is active (favors `std::format`, then `fmt::format`, then `std::ostream`).
-
-  ```cpp
-  using namespace csl::ag::io;
-  to_string(my_aggregate_value);                                    // compact, default     → {'a', {13}}
-  to_string<no_braces>(my_aggregate_value);                         // no outer brackets    → 'a'{13}
-  to_string<indented>(my_aggregate_value);                          // pretty, multi-line   → see below
-  to_string<indexed | typenamed | indented>(my_aggregate_value);    // pretty, multi-line, indexed, typenamed
-  ```
+> ⚠️ **Migration note** *(API break)*: the `CSL_AG__ENABLE_{STD_FORMAT,FMTLIB,IOSTREAM}_SUPPORT` macros and CMake options
+> were **removed** (silently ignored if still defined). Replace each with the matching feature-header `#include` above.  
+> `csl::ag::io::to_string` is now `std::format`-backed, and ships with `csl/ag/formatting/format.hpp` only.
 
 About compact vs. pretty presentations, with type names (`typenamed`):
 
@@ -819,21 +783,23 @@ Output:
 
 ### Formatting and printing
 
-There are three ways to pretty-print aggregate types :
+There are three ways to pretty-print aggregate types, each being an opt-in **feature header**:
 
-- (✅ Best) using `std::format` or the `fmt` library
-- using the C++'s legacy way : `std::ostream& operator<<(std::ostream&, T&&)` overload
-- using `csl::ag::io::to_string<format_options>`, a homogeneous (yet, less efficient) API across all of the above
+- (✅ Best) using `std::format` (`csl/ag/formatting/format.hpp`) or the `fmt` library (`csl/ag/formatting/fmt.hpp`)
+- using the C++'s legacy way : `std::ostream& operator<<(std::ostream&, T&&)` overload (`csl/ag/formatting/ostream.hpp`)
+- using `csl::ag::io::to_string<format_options>`, `std::format`-backed (ships with `csl/ag/formatting/format.hpp`)
+
+Backends may coexist in the same translation unit - each one specializes a different framework's entity.  
+The `typenamed` option renders compile-time, demangled type names when `csl/ag/formatting/typeinfo.hpp` is included,
+and falls back to `<typeindex>` runtime names otherwise.
 
 #### using std::format
 
-Requires `CSL_AG__ENABLE_STD_FORMAT_SUPPORT` (opt-in, off by default).  
-Enable via CMake or by defining the macro before including the header:
+Opt-in by include:
 
 ```cpp
-#define CSL_AG__ENABLE_STD_FORMAT_SUPPORT true
 #include <csl/ag.hpp>
-#include <format>
+#include <csl/ag/formatting/format.hpp>
 ```
 
 This specializes `std::formatter<T>` for any `csl::ag::concepts::aggregate T` whose fields are all formattable.
@@ -913,28 +879,28 @@ Mixed-content aggregates (containing tuple-likes, ranges, etc.) are also support
 
 #### using fmt
 
-Requires `CSL_AG__ENABLE_FMTLIB_SUPPORT` (opt-in, off by default) - same macro-driven setup as `std::format` above:
+Opt-in by include - same setup as `std::format` above:
 
 ```cpp
-#define CSL_AG__ENABLE_FMTLIB_SUPPORT true
 #include <csl/ag.hpp>
-#include <fmt/format.h>
+#include <csl/ag/formatting/fmt.hpp>
 ```
 
-> If `fmt::fmt-header-only` is not available as a CMake target, it will be fetched automatically via CMake's `FetchContent`.  
+> [fmtlib](https://github.com/fmtlib/fmt) is provided **by the consumer** (e.g. `find_package(fmt)`, then link `fmt::fmt` or `fmt::fmt-header-only`): the header uses it, `csl` never acquires nor ships it.  
 > fmtlib >= 11 is required for the `:n` specifier.
 
 `fmt::formatter<T>` / `fmt::format` / `fmt::print` behave identically to their `std::formatter` / `std::format` / `std::print` counterparts described above: same format modes, same composable `csl::ag::io::indented | indexed | typenamed` options, same output.  
 
 #### using std::ostream
 
+Opt-in by include: `csl/ag/formatting/ostream.hpp` *(prefer `std::format`/`fmt` when available: `<ostream>` is heavy at compile time, and options ride `std::ios_base::iword`)*.
+
 Simple example :
 
 <!-- EXAMPLE_BEGIN: 18_formatting_ostream_simple.cpp -->
 ```cpp
-#define CSL_AG__ENABLE_IOSTREAM_SUPPORT 1
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <iostream>
 
 auto main() -> int {
@@ -945,7 +911,7 @@ auto main() -> int {
 }
 ```
 
-[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/Wve3j19b9)
+[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/4763osbv1)
 <!-- EXAMPLE_END: 18_formatting_ostream_simple.cpp -->
 
 Output:
@@ -958,9 +924,8 @@ Advanced example :
 
 <!-- EXAMPLE_BEGIN: 19_formatting_ostream_advanced.cpp -->
 ```cpp
-#define CSL_AG__ENABLE_IOSTREAM_SUPPORT 1
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <array>
 #include <iostream>
 #include <string>
@@ -998,7 +963,7 @@ auto main() -> int {
 }
 ```
 
-[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/MY7PYePTd)
+[![CE][ce-icon] Try me on compiler-explorer](https://godbolt.org/z/xsTxxExrG)
 <!-- EXAMPLE_END: 19_formatting_ostream_advanced.cpp -->
 
 Output:
@@ -1009,13 +974,14 @@ Output:
 
 #### using `to_string<format_options>`
 
-`csl::ag::io::to_string` returns a `std::string` directly, with an consistent/homogeneous API regardless of which formatting support is enabled,  
-favoring `std::format`, then `fmt::format`, then `std::ostream`.
+`csl::ag::io::to_string` returns a `std::string` directly.  
+It is `std::format`-backed, and ships with `csl/ag/formatting/format.hpp`.
 
 Options are selected as a non-type template argument. Tags (`indented`, `no_braces`, `indexed`, `typenamed`) implicitly convert to `format_options` and compose via `operator|`, so they can be combined directly as the template argument - or, equivalently, via the view-based `operator|` on the value itself:
 
 ```cpp
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>
 
 struct point { int x; int y; };
 struct rect  { point top_left; point bottom_right; };

--- a/libs/ag/README.md
+++ b/libs/ag/README.md
@@ -782,10 +782,11 @@ Output:
 
 ### Formatting and printing
 
-There are two ways to pretty-print aggregate types, each being an opt-in **feature header**:
+There are 3 ways to pretty-print aggregate types, each being an opt-in **feature header** offering a dedicated backend wiring:
 
-- (✅ Best) using `std::format` (`csl/ag/formatting/backend/std_format.hpp`) or the `fmt` library (`csl/ag/formatting/backend/fmt.hpp`)
-- using the C++'s legacy way : `std::ostream& operator<<(std::ostream&, T&&)` overload (`csl/ag/formatting/backend/ostream.hpp`)
+- (✅ Best) Using `std::format` (`csl/ag/formatting/backend/std_format.hpp`)
+- (🟡 OK) Using the `fmt` library (`csl/ag/formatting/backend/fmt.hpp`) - best if `std::format` is not available.
+- (🔴 Worst) Using the C++'s legacy way : `std::ostream& operator<<(std::ostream&, T&&)` overload (`csl/ag/formatting/backend/ostream.hpp`)
 
 Backends may coexist in the same translation unit - each one specializes a different framework's entity.  
 The `typenamed` option renders compile-time, demangled type names when `csl/ag/formatting/typeinfo.hpp` is included,
@@ -810,13 +811,16 @@ Opt-in by include:
 
 This specializes `std::formatter<T>` for any `csl::ag::concepts::aggregate T` whose fields are all formattable.
 
-Three format modes are available:
+Format modes - each reachable as a format-spec letter, and/or as its composable-view equivalent (`"{}"` on the composed view; tags live in `csl::ag::io`):
 
-| Format string                              | Output style                                                 |
-| ------------------------------------------ | ------------------------------------------------------------ |
-| `"{}"`                                     | compact - fields wrapped in `{}`, nested aggregates recursed |
-| `"{:n}"`                                   | no outer brackets                                            |
-| `"{}"` on `value \| csl::ag::io::indented` | indented multi-line                                          |
+| Format string | View equivalent (`"{}"` on)                 | Output style                                                 |
+| ------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `"{}"`        | `value`                                     | compact - fields wrapped in `{}`, nested aggregates recursed |
+| `"{:n}"`      | `value \| no_braces`                        | no outer brackets (outermost-only)                           |
+| `"{:i}"`      | `value \| indented`                         | indented multi-line                                          |
+| `"{:x}"`      | `value \| indexed`                          | `[N]` field indexes                                          |
+| `"{:t}"`      | `value \| typenamed`                        | `TypeName:` field prefixes                                   |
+| `"{:ixt}"`    | `value \| indented \| indexed \| typenamed` | composed options (any combination, any order)                |
 
 Example:
 
@@ -832,10 +836,11 @@ constexpr auto r = rectangle{
 using namespace csl::ag::io;
 // NOTE: prefer std::print, if available
 std::cout
-    << std::format("{}\n",   r)                                     // compact
-    << std::format("{:n}\n", r)                                     // no brackets
-    << std::format("{}\n",   r | indented)                          // indented
-    << std::format("{}\n",   r | indexed | typenamed | indented)    // indexed, typenamed, indented
+    << std::format("{}\n",     r)                                   // compact
+    << std::format("{:n}\n",   r)                                   // no brackets
+    << std::format("{}\n",     r | indented)                        // indented
+    << std::format("{}\n",     r | indexed | typenamed | indented)  // indexed, typenamed, indented
+    << std::format("{:xti}\n", r)                                   // indexed, typenamed, indented
 ;
 ```
 
@@ -866,7 +871,7 @@ Indented (`| csl::ag::io::indented`):
 }
 ```
 
-Indexed and typenamed and indented (`| indexed | typenamed | indented`):
+Indexed and typenamed and indented (`{:xti}` and/or `| indexed | typenamed | indented`):
 
 ```text
 {

--- a/libs/ag/cmake/options.cmake
+++ b/libs/ag/cmake/options.cmake
@@ -2,10 +2,11 @@
 cmake_policy(SET CMP0127 NEW)
 include(CMakeDependentOption)
 
-# Opt-in feature flags are BUILD_INTERFACE-only:
+# Configuration macros are BUILD_INTERFACE-only:
 #   they apply while building csl itself (tests, examples) but are stripped from the installed/exported target,
 #   so the package stays neutral and dependency-free.
-#   Consumers of the installed package opt in themselves (define the macro, and for fmt provide the library) - see the ODR note in the README.
+# Formatting backends are NOT configured here: opt-in = #include of a feature header
+#   (csl/ag/formatting/{format,fmt,ostream,typeinfo}.hpp) - no CMake option, no macro.
 
 # CSL_AG__VERBOSE_BUILD
 option(CSL_AG__VERBOSE_BUILD "[${CMAKE_PROJECT_NAME}::${csl_add_component_NAME}]: verbose build (might use additional useful build messages)" OFF)
@@ -19,48 +20,6 @@ option(CSL_AG__ENABLE_BITFIELDS_SUPPORT "[${CMAKE_PROJECT_NAME}::${csl_add_compo
 csl_print_aligned(STATUS CSL_AG__ENABLE_BITFIELDS_SUPPORT)
 if (CSL_AG__ENABLE_BITFIELDS_SUPPORT)
     target_compile_definitions(csl_${csl_add_component_NAME} INTERFACE $<BUILD_INTERFACE:CSL_AG__ENABLE_BITFIELDS_SUPPORT>)
-endif()
-
-# CSL_AG__ENABLE_IOSTREAM_SUPPORT
-option(CSL_AG__ENABLE_IOSTREAM_SUPPORT "[${CMAKE_PROJECT_NAME}::${csl_add_component_NAME}]: enable iostream support (prefer fmtlib/std::format - see WARNING in ag.hpp)" OFF)
-csl_print_aligned(STATUS CSL_AG__ENABLE_IOSTREAM_SUPPORT)
-if (CSL_AG__ENABLE_IOSTREAM_SUPPORT)
-    target_compile_definitions(csl_${csl_add_component_NAME} INTERFACE $<BUILD_INTERFACE:CSL_AG__ENABLE_IOSTREAM_SUPPORT>)
-endif()
-
-# CSL_AG__ENABLE_STD_FORMAT_SUPPORT
-option(CSL_AG__ENABLE_STD_FORMAT_SUPPORT "[${CMAKE_PROJECT_NAME}::${csl_add_component_NAME}]: enable std::format support" OFF)
-csl_print_aligned(STATUS CSL_AG__ENABLE_STD_FORMAT_SUPPORT)
-if (CSL_AG__ENABLE_STD_FORMAT_SUPPORT)
-    target_compile_definitions(csl_${csl_add_component_NAME} INTERFACE $<BUILD_INTERFACE:CSL_AG__ENABLE_STD_FORMAT_SUPPORT>)
-endif()
-
-# CSL_AG__ENABLE_FMTLIB_SUPPORT
-option(CSL_AG__ENABLE_FMTLIB_SUPPORT "[${CMAKE_PROJECT_NAME}::${csl_add_component_NAME}]: enable fmt support" OFF)
-csl_print_aligned(STATUS CSL_AG__ENABLE_FMTLIB_SUPPORT)
-if (${CSL_AG__ENABLE_FMTLIB_SUPPORT})
-
-    target_compile_definitions(csl_${csl_add_component_NAME} INTERFACE $<BUILD_INTERFACE:CSL_AG__ENABLE_FMTLIB_SUPPORT>)
-
-    if (NOT TARGET fmt::fmt-header-only AND NOT TARGET fmt::fmt)
-        include(csl/get_cpm)
-        csl_get_cpm()
-        CPMAddPackage(
-            NAME              fmt
-            GITHUB_REPOSITORY fmtlib/fmt
-            GIT_TAG           12.1.0
-        )
-    endif()
-
-    if (TARGET fmt::fmt-header-only)
-        add_dependencies(csl_${csl_add_component_NAME} fmt::fmt-header-only)
-        target_link_libraries(csl_${csl_add_component_NAME} INTERFACE $<BUILD_INTERFACE:fmt::fmt-header-only>)
-    elseif(TARGET fmt::fmt)
-        add_dependencies(csl_${csl_add_component_NAME} fmt::fmt)
-        target_link_libraries(csl_${csl_add_component_NAME} INTERFACE $<BUILD_INTERFACE:fmt::fmt>)
-    else()
-        message(FATAL_ERROR "[${CMAKE_PROJECT_NAME}::${csl_add_component_NAME}]: unexpected ill-formed fmt library")
-    endif()
 endif()
 
 # --- code generation ---

--- a/libs/ag/examples/01_overview_demo.cpp
+++ b/libs/ag/examples/01_overview_demo.cpp
@@ -1,6 +1,7 @@
-#include <csl/typeinfo.hpp> // optional: gives csl::ag::io::typenamed clean type names (e.g. "int")
-#define CSL_AG__ENABLE_STD_FORMAT_SUPPORT 1
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support (+ csl::ag::io::to_string)
+#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 #include <iostream> // std::print might not be available yet: use `std::cout << std::format(...)`
 
 struct S { char c; int i; };
@@ -20,9 +21,9 @@ auto main() -> int {
     constexpr auto format_options = indexed | typenamed | indented;
     std::cout << std::format("{}", value | format_options); // equivalent to std::println("{:xit}", value)
 
-    // legacy alternative: CSL_AG__ENABLE_IOSTREAM_SUPPORT
+    // alternative: #include <csl/ag/formatting/ostream.hpp>
     // std::cout << "value: " << format_options << value << '\n';
 
-    // other alternative: CSL_AG__ENABLE_FMT_SUPPORT
+    // alternative: #include <csl/ag/formatting/fmt.hpp>
     // fmt::println("{:xit}", value)
 }

--- a/libs/ag/examples/01_overview_demo.cpp
+++ b/libs/ag/examples/01_overview_demo.cpp
@@ -1,5 +1,5 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support (+ csl::ag::io::to_string)
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
 #include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
 #include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 #include <iostream> // std::print might not be available yet: use `std::cout << std::format(...)`

--- a/libs/ag/examples/01_overview_demo.cpp
+++ b/libs/ag/examples/01_overview_demo.cpp
@@ -1,8 +1,8 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
-#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
-#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
-#include <iostream> // std::print might not be available yet: use `std::cout << std::format(...)`
+#include <csl/ag/formatting/backend/std_format.hpp> // opt-in: std::formatter support
+#include <csl/typeinfo.hpp>                         // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp>           // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
+#include <iostream>                                 // std::print might not be available yet: use `std::cout << std::format(...)`
 
 struct S { char c; int i; };
 
@@ -21,9 +21,9 @@ auto main() -> int {
     constexpr auto format_options = indexed | typenamed | indented;
     std::cout << std::format("{}", value | format_options); // equivalent to std::println("{:xit}", value)
 
-    // alternative: #include <csl/ag/formatting/ostream.hpp>
+    // alternative: #include <csl/ag/formatting/backend/ostream.hpp>
     // std::cout << "value: " << format_options << value << '\n';
 
-    // alternative: #include <csl/ag/formatting/fmt.hpp>
+    // alternative: #include <csl/ag/formatting/backend/fmt.hpp>
     // fmt::println("{:xit}", value)
 }

--- a/libs/ag/examples/18_formatting_ostream_simple.cpp
+++ b/libs/ag/examples/18_formatting_ostream_simple.cpp
@@ -1,6 +1,5 @@
-#define CSL_AG__ENABLE_IOSTREAM_SUPPORT 1
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <iostream>
 
 auto main() -> int {

--- a/libs/ag/examples/18_formatting_ostream_simple.cpp
+++ b/libs/ag/examples/18_formatting_ostream_simple.cpp
@@ -1,5 +1,5 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
+#include <csl/ag/formatting/backend/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <iostream>
 
 auto main() -> int {

--- a/libs/ag/examples/19_formatting_ostream_advanced.cpp
+++ b/libs/ag/examples/19_formatting_ostream_advanced.cpp
@@ -1,6 +1,5 @@
-#define CSL_AG__ENABLE_IOSTREAM_SUPPORT 1
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <array>
 #include <iostream>
 #include <string>

--- a/libs/ag/examples/19_formatting_ostream_advanced.cpp
+++ b/libs/ag/examples/19_formatting_ostream_advanced.cpp
@@ -1,5 +1,5 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
+#include <csl/ag/formatting/backend/ostream.hpp> // opt-in: operator<<(std::ostream &, ...) support
 #include <array>
 #include <iostream>
 #include <string>

--- a/libs/ag/examples/22_formatting_fmtlib_simple.cpp
+++ b/libs/ag/examples/22_formatting_fmtlib_simple.cpp
@@ -1,7 +1,7 @@
-#include <csl/typeinfo.hpp> // optional: gives csl::ag::io::typenamed clean type names (e.g. "int")
-#define CSL_AG__ENABLE_FMTLIB_SUPPORT 1
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/fmt.hpp>      // opt-in: fmt::formatter support
+#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 
 auto main() -> int {
     using namespace csl::ag::io;

--- a/libs/ag/examples/22_formatting_fmtlib_simple.cpp
+++ b/libs/ag/examples/22_formatting_fmtlib_simple.cpp
@@ -1,7 +1,7 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/fmt.hpp>      // opt-in: fmt::formatter support
-#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
-#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
+#include <csl/ag/formatting/backend/fmt.hpp> // opt-in: fmt::formatter support
+#include <csl/typeinfo.hpp>                  // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp>    // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 
 auto main() -> int {
     using namespace csl::ag::io;

--- a/libs/ag/examples/23_formatting_std_format_simple.cpp
+++ b/libs/ag/examples/23_formatting_std_format_simple.cpp
@@ -1,7 +1,7 @@
-#include <csl/typeinfo.hpp> // optional: gives csl::ag::io::typenamed clean type names (e.g. "int")
-#define CSL_AG__ENABLE_STD_FORMAT_SUPPORT 1
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support (+ csl::ag::io::to_string)
+#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 #include <format>
 #include <iostream>
 

--- a/libs/ag/examples/23_formatting_std_format_simple.cpp
+++ b/libs/ag/examples/23_formatting_std_format_simple.cpp
@@ -1,5 +1,5 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support (+ csl::ag::io::to_string)
+#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
 #include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
 #include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 #include <format>

--- a/libs/ag/examples/23_formatting_std_format_simple.cpp
+++ b/libs/ag/examples/23_formatting_std_format_simple.cpp
@@ -1,7 +1,7 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>   // opt-in: std::formatter support
-#include <csl/typeinfo.hpp>               // bridge prerequisite (explicit, for godbolt raw-URL include order)
-#include <csl/ag/formatting/typeinfo.hpp> // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
+#include <csl/ag/formatting/backend/std_format.hpp> // opt-in: std::formatter support
+#include <csl/typeinfo.hpp>                         // bridge prerequisite (explicit, for godbolt raw-URL include order)
+#include <csl/ag/formatting/typeinfo.hpp>           // opt-in: gives csl::ag::io::typenamed clean type names (e.g. "int")
 #include <format>
 #include <iostream>
 

--- a/libs/ag/examples/overview.cpp
+++ b/libs/ag/examples/overview.cpp
@@ -1,5 +1,5 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp> // opt-in: std::formatter support
+#include <csl/ag/formatting/backend/std_format.hpp> // opt-in: std::formatter support
 
 #include <cstdint>
 #include <format>
@@ -74,11 +74,11 @@ auto main(int, char*[]) -> int
     static_assert(std::tuple_size_v<decltype(view)> == 2);
     static_assert(std::get<0>(view) == 3);
 
-    // --- opt-in: std::format formatting (#include <csl/ag/formatting/format.hpp>) ---
+    // --- opt-in: std::format formatting (#include <csl/ag/formatting/backend/std_format.hpp>) ---
     std::cout << std::format("{}\n", value);                          // compact:  (3, 4)
     std::cout << std::format("{}\n", value | csl::ag::io::indented);  // indented: multi-line
 
-    // --- opt-in: fmt formatting (#include <csl/ag/formatting/fmt.hpp>) ---
+    // --- opt-in: fmt formatting (#include <csl/ag/formatting/backend/fmt.hpp>) ---
     // fmt::print("{}\n", value);
     // fmt::print("{}\n", value | csl::ag::io::indented);
 }

--- a/libs/ag/examples/overview.cpp
+++ b/libs/ag/examples/overview.cpp
@@ -1,6 +1,9 @@
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp> // opt-in: std::formatter support
 
 #include <cstdint>
+#include <format>
+#include <iostream>
 #include <tuple>
 
 struct point  { int x, y; };
@@ -71,16 +74,12 @@ auto main(int, char*[]) -> int
     static_assert(std::tuple_size_v<decltype(view)> == 2);
     static_assert(std::get<0>(view) == 3);
 
-    // --- opt-in: fmt formatting (CSL_AG__ENABLE_FMTLIB_SUPPORT) ---
-#if defined(CSL_AG__ENABLE_FMTLIB_SUPPORT)
-    fmt::print("{}\n", value);  // compact:  (3, 4)
-    fmt::print("{}\n", value | csl::ag::io::indented);  // indented: multi-line
-#endif
+    // --- opt-in: std::format formatting (#include <csl/ag/formatting/format.hpp>) ---
+    std::cout << std::format("{}\n", value);                          // compact:  (3, 4)
+    std::cout << std::format("{}\n", value | csl::ag::io::indented);  // indented: multi-line
 
-    // --- opt-in: std::format (CSL_AG__ENABLE_STD_FORMAT_SUPPORT) ---
-#if defined(CSL_AG__ENABLE_STD_FORMAT_SUPPORT)
-    std::print("{}\n", value);
-    std::print("{}\n", value | csl::ag::io::indented);
-#endif
+    // --- opt-in: fmt formatting (#include <csl/ag/formatting/fmt.hpp>) ---
+    // fmt::print("{}\n", value);
+    // fmt::print("{}\n", value | csl::ag::io::indented);
 }
 // NOLINTEND(*-magic-numbers)

--- a/libs/ag/includes/ag/csl/ag.hpp
+++ b/libs/ag/includes/ag/csl/ag.hpp
@@ -1181,10 +1181,10 @@ namespace csl::ag::tuplelike {
 //
 // Formatting backends are opt-in feature headers, include them consistently program-wide:
 //
-//  <csl/ag/formatting/format.hpp>      std::formatter support
-//  <csl/ag/formatting/fmt.hpp>         fmt::formatter support (fmtlib is provided by the consumer)
-//  <csl/ag/formatting/ostream.hpp>     operator<<(std::ostream &, ...) support
-//  <csl/ag/formatting/typeinfo.hpp>    compile-time type names for the typenamed option (csl::typeinfo-backed)
+//  <csl/ag/formatting/backend/std_format.hpp>  std::formatter support
+//  <csl/ag/formatting/backend/fmt.hpp>         fmt::formatter support (fmtlib is provided by the consumer)
+//  <csl/ag/formatting/backend/ostream.hpp>     operator<<(std::ostream &, ...) support
+//  <csl/ag/formatting/typeinfo.hpp>            compile-time type names for the typenamed option (csl::typeinfo-backed)
 
 // type_name
 #pragma region type_name

--- a/libs/ag/includes/ag/csl/ag.hpp
+++ b/libs/ag/includes/ag/csl/ag.hpp
@@ -3,6 +3,9 @@
 // under MIT License - Copyright (c) 2021 Guillaume Dua "Guss"
 // https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
 
+// NOTE: Detectable by other csl libraries/headers (via #if defined(...)), even when not reachable through __has_include (e.g. Compiler Explorer raw-URL includes).
+#define CSL_AG__INCLUDED
+
 #if not __cplusplus >= 202002L
 # error "csl/ag.hpp requires C++20"
 #endif
@@ -1073,13 +1076,11 @@ namespace csl::ag {
 //  If std::tuple_size<T> were specialized for non-STL aggregates,
 //  then the generated make_to_tuple<N> templates would require get<I>(value) to be ADL-findable for T.
 //  csl::ag::get is defined AFTER the generated include, so it is not visible via non-ADL unqualified lookup at the template definition site.
-//  For user-defined aggregate types outside namespace csl::ag, ADL does not search
-//  csl::ag either - making get<I> irrecoverably unfindable for them.
+//  For user-defined aggregate types outside namespace csl::ag, ADL does not search csl::ag either - making get<I> irrecoverably unfindable for them.
 //
 //  The generated code exists because C++ has no introspection for aggregate field types:
-//  make_to_tuple<N> uses structured bindings at consteval time to capture field types
-//  as a std::tuple via decltype, producing the std::type_identity<std::tuple<Ts...>>
-//  that drives csl::ag::element<I, T> and csl::ag::to_tuple_t<T>.
+//  make_to_tuple<N> uses structured bindings at consteval time to capture field types as a std::tuple via decltype,
+//  producing the std::type_identity<std::tuple<Ts...>> that drives csl::ag::element<I, T> and csl::ag::to_tuple_t<T>.
 
 namespace csl::ag::tuplelike::concepts {
     template <typename T>
@@ -1166,52 +1167,63 @@ namespace csl::ag::tuplelike {
     }
 }
 
-// ---------------------
-//  formatting/printing
-// ---------------------
-
-#if (defined(CSL_AG__ENABLE_IOSTREAM_SUPPORT)   and CSL_AG__ENABLE_IOSTREAM_SUPPORT) \
- or (defined(CSL_AG__ENABLE_FMTLIB_SUPPORT)     and CSL_AG__ENABLE_FMTLIB_SUPPORT) \
- or (defined(CSL_AG__ENABLE_STD_FORMAT_SUPPORT) and CSL_AG__ENABLE_STD_FORMAT_SUPPORT)
-# define CSL_AG__FORMATTING_ENABLED true
-# endif
+// ------------------------------
+//  formatting/printing - io core
+// ------------------------------
+//
+// csl/ag.hpp only ships the backend-agnostic io core (std-only, always compiled, no blanket specialization):
+// - format options
+// - format tags
+// - decorated views
+// - view operator|
+// - type_name CPO (customization trait)
+// - formatters shared machinery.
+//
+// Formatting backends are opt-in feature headers, include them consistently program-wide:
+//
+//  <csl/ag/formatting/format.hpp>      std::formatter support, csl::ag::io::to_string
+//  <csl/ag/formatting/fmt.hpp>         fmt::formatter support (fmtlib is provided by the consumer)
+//  <csl/ag/formatting/ostream.hpp>     operator<<(std::ostream &, ...) support
+//  <csl/ag/formatting/typeinfo.hpp>    compile-time type names for the typenamed option (csl::typeinfo-backed)
 
 // type_name
-#if defined(CSL_AG__FORMATTING_ENABLED)
 #pragma region type_name
 
-#if defined(CSL_TYPEINFO__INCLUDED) or __has_include(<csl/typeinfo.hpp>)
-#   if not defined(CSL_TYPEINFO__INCLUDED)
-#       include <csl/typeinfo.hpp>
-#   endif
-namespace csl::ag::io::details {
+#include <typeindex>
 
-    template <typename T>
-    struct type_name : csl::typeinfo::type_name<T>{};
-    template <typename T>
-    constexpr inline static std::string_view type_name_v = type_name<T>::value;
-}
-#else
-#   pragma message("[csl::ag](EXPERIMENTALE) formatting enabled, but <csl/typeinfo.hpp> not available, fallback to <typeindex>. Relies on runtime implementation.")
-#   include <typeindex>
-namespace csl::ag::io::details {
+namespace csl::ag::io {
 
+    /// @brief Customization point (type-trait) providing the type name written by the @c typenamed formatting option.
+    ///
+    /// The primary template is a runtime fallback: @c std::type_index(typeid(T)).name(), which is implementation-defined and possibly mangled.
+    ///
+    /// To obtain readable names, either:
+    /// - @c \#include @c <csl/ag/formatting/typeinfo.hpp> for compile-time, demangled names (csl::typeinfo-backed),
+    /// - or specialize this trait for specific types/concepts/constraints.
+    ///
+    /// @tparam T the type whose name is queried.
     template <typename T>
     struct type_name {
         static inline const std::string_view value = std::type_index(typeid(T)).name();
     };
+    
+    /// @brief Alias for @c type_name<T>::value, the type name written by the @c typenamed option.
+    ///
+    /// @note Deliberately a @c constexpr reference, not a copy.
+    /// Per @c [basic.start.dynamic], instantiated specializations have @e unordered dynamic initialization;
+    /// a local copy of @c type_name<T>::value could be initialized before its source and capture an empty @c string_view.
+    //
+    /// The binding is an address constant expression even for the runtime primary template, so @c type_name_v is guaranteed constant-initialized,
+    /// and usable in constant expressions whenever the specialization's @c value is @c constexpr (e.g. @c <csl/ag/formatting/typeinfo.hpp>).
+    ///
+    /// @tparam T the type whose name is queried.
     template <typename T>
-    const inline static std::string_view type_name_v = type_name<T>::value;
+    constexpr static inline const std::string_view & type_name_v = type_name<T>::value;
 }
-#endif
 
 #pragma endregion
-#endif
 
 // Formatting(shared): composable format options, tag types, decorated view, operator|
-#if defined(CSL_AG__FORMATTING_ENABLED)
-
-#pragma message("[csl::ag] Formatting enabled")
 
 namespace csl::ag::io {
     /// \brief Bitmask of composable formatting options.
@@ -1315,8 +1327,10 @@ namespace csl::ag::io::details::decorators {
 }
 
 namespace csl::ag::io::details::concepts {
+    // NOTE: type-requirement (typename): csl_ag_io_decorator is a member type alias -
+    //       a simple-requirement would test it as an (invalid) expression and never be satisfied
     template <typename T>
-    concept decorator = requires { T::csl_ag_io_decorator; };
+    concept decorator = requires { typename T::csl_ag_io_decorator; };
 }
 
 namespace csl::ag::io {
@@ -1354,13 +1368,13 @@ namespace csl::ag::io::details::style {
 
     template <typename T>
     [[nodiscard]] constexpr auto opening_bracket() noexcept -> std::string_view {
-             if constexpr (csl::ag::concepts::range_like<T>)    return "[";
+        if constexpr (csl::ag::concepts::range_like<T>)         return "[";
         else if constexpr (csl::ag::concepts::tuple_like<T>)    return "(";
         else                                                    return "{";
     }
     template <typename T>
     [[nodiscard]] constexpr auto closing_bracket() noexcept -> std::string_view {
-             if constexpr (csl::ag::concepts::range_like<T>)    return "]";
+        if constexpr (csl::ag::concepts::range_like<T>)         return "]";
         else if constexpr (csl::ag::concepts::tuple_like<T>)    return ")";
         else                                                    return "}";
     }
@@ -1387,10 +1401,7 @@ namespace csl::ag::io::details::style {
     }
 }
 
-#endif
-
-#if (defined(CSL_AG__ENABLE_FMTLIB_SUPPORT) and CSL_AG__ENABLE_FMTLIB_SUPPORT) \
- or (defined(CSL_AG__ENABLE_STD_FORMAT_SUPPORT) and CSL_AG__ENABLE_STD_FORMAT_SUPPORT)
+// Formatters shared machinery (fmt::formatter / std::formatter): backend-agnostic, std-only.
 
 namespace csl::ag::io::details {
 
@@ -1398,7 +1409,8 @@ namespace csl::ag::io::details {
     [[nodiscard]] consteval auto to_chars() noexcept {
 
         constexpr auto digits = [] {
-            std::size_t n = N, count = 1;
+            std::size_t n = N;
+            std::size_t count = 1;
             while (n >= 10) { n /= 10; ++count; }
             return count;
         }();
@@ -1428,15 +1440,16 @@ namespace csl::ag::io::details {
     }
 
     /// \brief Maps a formatter_implementation (fmt::formatter or std::formatter) to its matching format-error exception type
+    ///        Note that the 3rd ttp of fmt::formatter is defaulted (SFINAE, void)
     template <template <typename, typename> class formatter_implementation>
     struct format_error_type;
     template <template <typename, typename> class formatter_implementation>
     using format_error_type_t = typename format_error_type<formatter_implementation>::type;
 
     /// \brief Formatters shared logic (fmt and std) -> parse, format.
-    /// Format options/depth are carried at runtime by the formatted_view_t decorator (see operator|), not baked into this type's template parameters.
-    /// parse() additionally accumulates a parse_options mask from the format-spec string (e.g. ':n'),
-    /// merged with the decorator's options for this node only - it is not propagated to field formatters.
+    ///        Format options/depth are carried at runtime by the formatted_view_t decorator (see operator|), not as TTPs.
+    ///        parse() additionally accumulates a parse_options mask from the format-spec string (e.g. ':n'),
+    ///        merged with the decorator's options for this node only - it is not propagated to field formatters.
     /// \tparam formatter_implementation fmt::formatter or std::formatter (yet, unconstrained here)
     /// \tparam T the structured-bindable aggregate type being formatted
     /// \tparam Char the character type
@@ -1622,486 +1635,6 @@ namespace csl::ag::io::details {
         }
     };
 }
-
-#endif // fmtlib or std::format base
-
-//  Formatting: ostream support
-//
-// Provides operator<<(std::ostream &, structured_bindable) via csl::ag::io.
-//
-// WARNING: prefer fmtlib or std::format support over this when available.
-//
-//   Compile-time cost:
-//      Including <ostream> is one of the heaviest standard headers.
-//      Prefer fmtlib (CSL_AG__ENABLE_FMTLIB_SUPPORT) or std::format (CSL_AG__ENABLE_STD_FORMAT_SUPPORT) for significantly faster build times.
-//
-//   Runtime cost:
-//      std::ios_base::xalloc() and std::ios_base::iword() are used to store the active options on the stream.
-//      Both involve a global mutex and can be a bottleneck in hot paths or multi-threaded code.
-//
-// Design:
-//  - Composable format_options bitmask selected via IO manipulators (one-shot, reset after each print)
-//      or via the view-based operator| API (bypasses iword entirely):
-//      os << value                                          (default: braced, compact)
-//      os << csl::ag::io::no_braces << value                (flat, naked: no outer brackets or separator)
-//      os << csl::ag::io::indented  << value                (multiline, depth-indented)
-//      os << csl::ag::io::indexed   << value                (braced with [N] field indexes)
-//      os << csl::ag::io::typenamed << value                (braced with TypeName: prefixes)
-//      os << (value | csl::ag::io::indented | csl::ag::io::indexed)  (view-based, composable)
-//  - Options propagate to nested structured_bindable fields (no_braces is outermost-only)
-//  - Leaf values consistent with fmtlib: char => 'x', bool => true/false, string => "..."
-//
-// Usage: using namespace csl::ag::io; std::cout << my_aggregate;
-
-#if defined(CSL_AG__ENABLE_IOSTREAM_SUPPORT) and CSL_AG__ENABLE_IOSTREAM_SUPPORT
-
-#pragma message("[csl::ag] CSL_AG__ENABLE_IOSTREAM_SUPPORT - enabled")
-
-#include <ostream>
-#include <sstream>
-
-namespace csl::ag::io::details {
-
-    /// \brief T has an operator<<(std::ostream &, T) reachable WITHOUT csl::ag::io in scope.
-    // This prevents this library operator<< from satisfying the concept (depend on self).
-    template <typename T>
-    concept ostream_formattable = requires(std::ostream & os, const std::remove_cvref_t<T> & v) {
-        os << v;
-    };
-
-    static inline auto mode_index() noexcept -> int {
-        static const int index = std::ios_base::xalloc();
-        return index;
-    }
-
-    inline void write_indent(std::ostream & os, std::size_t depth) {
-        constexpr std::size_t max_depth = 32;
-        static constexpr auto buf =
-            []<std::size_t... Is>(std::index_sequence<Is...>) {
-                return std::array<char, sizeof...(Is)>{((void)Is, ' ')...};
-            }(std::make_index_sequence<max_depth * style::indentation_width>{});
-        os.write(buf.data(), static_cast<std::streamsize>(std::min(max_depth, depth) * style::indentation_width));
-    }
-
-    struct format_options_view {
-
-        bool is_indented;
-        bool is_no_braces;
-        bool is_indexed;
-        bool is_typenamed;
-        format_options nested; // no_braces is outermost-only
-
-        constexpr explicit format_options_view(format_options options) noexcept
-            : is_indented  { bool(options & format_options::indented)  }
-            , is_no_braces { bool(options & format_options::no_braces) }
-            , is_indexed   { bool(options & format_options::indexed)   }
-            , is_typenamed { bool(options & format_options::typenamed) }
-            , nested       { options & ~format_options::no_braces      }
-        {}
-    };
-
-    // NOTE: Forward declaration: print and print_field_value are mutually recursive.
-    template <csl::ag::concepts::structured_bindable T>
-    void print(std::ostream & os, T && value, format_options options, std::size_t depth)
-    requires (not std::is_array_v<std::remove_cvref_t<T>>);
-
-    /// \brief print_field_value: write one field value of type T to an ostream value.
-    // Quoting is consistent with fmtlib: char => 'x', bool => true/false, string => "...".
-    // WARNING(Known limitation) range-like and tuple-like field values are not recursively pretty-printed;
-    //   they require a user-provided operator<< or they hit the static_assert.
-    // TODO: get rid of such a limitation, for consistency sake ?
-    template <typename T>
-    void print_field_value(std::ostream & os, T && value, format_options options, std::size_t depth) {
-        using type = std::remove_cvref_t<T>;
-        if constexpr (std::is_same_v<type, bool>)
-            os << (value ? "true" : "false");
-        else if constexpr (std::is_same_v<type, char>)
-            os << '\'' << value << '\'';
-        else if constexpr (std::is_same_v<type, std::string_view> or std::is_same_v<type, std::string>)
-            os << '"' << value << '"';
-        else if constexpr (ostream_formattable<type>)
-            os << value;
-        else if constexpr (csl::ag::concepts::structured_bindable<type> and not std::is_array_v<type>)
-            print(os, csl_fwd(value), options, depth);
-        else
-            static_assert(false, "[csl::ag::io] field type is not printable: provide operator<<(std::ostream &, T)");
-    }
-
-    template <csl::ag::concepts::structured_bindable T>
-    void print(std::ostream & os, T && value, format_options options, std::size_t depth)
-    requires (not std::is_array_v<std::remove_cvref_t<T>>)
-    {
-        using type = std::remove_cvref_t<T>;
-        constexpr auto size = csl::ag::tuplelike::size_v<type>;
-
-        const auto opt = format_options_view{ options };
-
-        if (not opt.is_no_braces) os << style::opening_bracket<type>();
-        if (opt.is_indented)      os << '\n';
-
-        [&]<std::size_t ... indexes>(std::index_sequence<indexes...>) {
-            ([&] {
-                
-                if constexpr (indexes > 0) {
-                    if (not opt.is_no_braces)       os << ',';
-                    if (opt.is_indented)            os << '\n';
-                    else if (not opt.is_no_braces)  os << ' ';
-                }
-                
-                if (opt.is_indented)
-                    write_indent(os, depth + 1);
-
-                if (opt.is_indexed)
-                    os << '[' << indexes << "] ";
-                
-                if (opt.is_typenamed) {
-                    using field_type = csl::ag::tuplelike::element_t<indexes, type>;
-                    os << type_name_v<field_type> << ": ";
-                }
-                print_field_value(
-                    os,
-                    csl::ag::tuplelike::get<indexes>(csl_fwd(value)),
-                    opt.nested,
-                    depth + 1
-                );
-            }(), ...);
-        }(std::make_index_sequence<size>{});
-
-        if (opt.is_indented){
-            os << '\n';
-            write_indent(os, depth);
-        }
-        if (not opt.is_no_braces)
-            os << style::closing_bracket<type>();
-    }
-}
-
-namespace csl::ag::io {
-
-    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - indented
-    inline auto operator<<(std::ostream & os, indented_t) -> std::ostream & {
-        os.iword(details::mode_index()) |= std::to_underlying(format_options::indented);
-        return os;
-    }
-    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - no_braces
-    inline auto operator<<(std::ostream & os, no_braces_t) -> std::ostream & {
-        os.iword(details::mode_index()) |= std::to_underlying(format_options::no_braces);
-        return os;
-    }
-    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - indexed
-    inline auto operator<<(std::ostream & os, indexed_t) -> std::ostream & {
-        os.iword(details::mode_index()) |= std::to_underlying(format_options::indexed);
-        return os;
-    }
-    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - typenamed
-    inline auto operator<<(std::ostream & os, typenamed_t) -> std::ostream & {
-        os.iword(details::mode_index()) |= std::to_underlying(format_options::typenamed);
-        return os;
-    }
-    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - precomputed bitmask
-    /// Mirrors the tag-based manipulators above, for a `format_options` combined ahead of time, e.g.
-    /// `constexpr auto options = indented | indexed | typenamed; os << options << value;`
-    inline auto operator<<(std::ostream & os, format_options options) -> std::ostream & {
-        os.iword(details::mode_index()) |= std::to_underlying(options);
-        return os;
-    }
-
-    /// \brief std::ostream formatting using formatted_view. Effectively bypasses iword.
-    template <typename T>
-    static auto operator<<(std::ostream & os, details::decorators::formatted_view_t<T> const & view)
-    -> std::ostream &
-    {
-        details::print(os, view.value, view.options, view.depth);
-        return os;
-    }
-
-    /// \brief Format a structured_bindable into an std::ostream, using iword options (one-shot) and prints.
-    /// User-defined operator<<(std::ostream &, T) wins via overload resolution (exact match).
-    auto operator<<(std::ostream & os, const csl::ag::concepts::structured_bindable auto & value)
-    -> std::ostream &
-    requires (not std::is_array_v<std::remove_cvref_t<decltype(value)>>)
-    and (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
-    {
-        auto options = static_cast<format_options>(os.iword(details::mode_index()));
-        os.iword(details::mode_index()) = 0; // reset (one-shot semantics)
-        details::print(os, value, options, 0);
-        return os;
-    }
-
-}
-
-#endif // CSL_AG__ENABLE_IOSTREAM_SUPPORT
-
-// Opt-in: fmt support
-#if defined(CSL_AG__ENABLE_FMTLIB_SUPPORT) and CSL_AG__ENABLE_FMTLIB_SUPPORT and not __has_include(<fmt/format.h>)
-    static_assert(false, "csl::ag: [CSL_AG_ENABLE_FMTLIB_SUPPORT] set to [true], but header <fmt/format.h> is missing. Did you forget a dependency ?");
-#elif defined(CSL_AG__ENABLE_FMTLIB_SUPPORT) and CSL_AG__ENABLE_FMTLIB_SUPPORT
-
-#pragma message("[csl::ag] CSL_AG__ENABLE_FMTLIB_SUPPORT - enabled")
-
-# include <fmt/ranges.h>
-# include <fmt/compile.h>
-
-namespace csl::ag::io::type_traits {
-
-    // formatter_value_type
-    template <typename T>
-    struct formatter_value_type;
-    template <typename T, typename Char>
-    struct formatter_value_type<fmt::formatter<T, Char>> : std::type_identity<T>{};
-    template <typename T>
-    using formatter_value_type_t = formatter_value_type<T>::type;
-
-}
-
-// fmt_formatter alias: normalises fmt::formatter's 3-param signature to 2 params
-// so it can be passed as a template template parameter to ag_formatter_base.
-namespace csl::ag::io::details {
-    template <typename T, typename Char = char>
-    using fmt_formatter = fmt::formatter<T, Char>;
-
-    template <>
-    struct format_error_type<fmt_formatter> : std::type_identity<fmt::format_error>{};
-}
-
-// fmt_formattable (used upstream: not formatter detection)
-namespace csl::ag::io::details::type_traits {
-    template <typename T, typename Char>
-    struct is_fmt_formattable : fmt::is_formattable<T, Char>{};
-    template <csl::ag::concepts::structured_bindable T, typename Char>
-    struct is_fmt_formattable<T, Char> {
-        constexpr static auto value = []<std::size_t ... indexes>(std::index_sequence<indexes...>){
-            return (true and ... and fmt::is_formattable<csl::ag::tuplelike::element_t<indexes, T>>::value);
-        }(std::make_index_sequence<csl::ag::tuplelike::size_v<T>>{});
-    };
-    template <typename T, typename Char>
-    constexpr inline static auto is_fmt_formattable_v = is_fmt_formattable<T, Char>::value;
-}
-namespace csl::ag::io::details::concepts {
-
-    template <typename T, typename Char>
-    concept fmt_formattable = type_traits::is_fmt_formattable_v<T, Char>;
-}
-
-/// \brief fmt::formatter for plain aggregate T - default (braced, flat) output.
-/// WARNING: routes through ag_formatter_base, not fmt's native tuple_join_view formatter,
-/// per-element format-spec propagation (fmt feature enabler: FMT_TUPLE_JOIN_SPECIFIERS) is not used/available here.
-/// See simplification commit 000e7d2fb749bca03aadc80b22bad7e2f6d27f26
-template <csl::ag::concepts::aggregate T, typename Char>
-requires (not csl::ag::io::details::concepts::decorator<T>)
-and (not std::ranges::range<T>)
-class fmt::formatter<T, Char>
-    : public csl::ag::io::details::ag_formatter_base<
-        csl::ag::io::details::fmt_formatter, T, Char
-    >
-{};
-
-#pragma region // formatted_view_t formatters (composable options)
-
-namespace csl::ag::io::type_traits {
-    template <typename T, typename Char>
-    struct formatter_value_type<
-        fmt::formatter<csl::ag::io::details::decorators::formatted_view_t<T>, Char>
-    > : std::type_identity<T>{};
-}
-
-// fmt::formatter for formatted_view_t - composite structured_bindable T
-template <
-    csl::ag::concepts::structured_bindable T,
-    typename Char
->
-requires (not csl::ag::io::details::concepts::decorator<T>)
-and csl::ag::io::details::concepts::fmt_formattable<T, Char>
-class fmt::formatter<
-    csl::ag::io::details::decorators::formatted_view_t<T>,
-    Char
-> : public csl::ag::io::details::ag_formatter_base<
-        csl::ag::io::details::fmt_formatter, T, Char
-    >
-{};
-
-// fmt::formatter for formatted_view_t - non-structured-bindable leaf T
-template <
-    typename T,
-    typename Char
->
-requires (not csl::ag::concepts::structured_bindable<T>)
-class fmt::formatter<
-    csl::ag::io::details::decorators::formatted_view_t<T>,
-    Char
-> : public csl::ag::io::details::ag_formatter_base_leaf<
-        csl::ag::io::details::fmt_formatter, T, Char
-    >
-{};
-#pragma endregion
-
-#endif // CSL_AG__ENABLE_FMTLIB_SUPPORT
-
-// Opt-in: std::format support
-#if defined(CSL_AG__ENABLE_STD_FORMAT_SUPPORT) and CSL_AG__ENABLE_STD_FORMAT_SUPPORT and not __has_include(<format>)
-    static_assert(false, "csl::ag: [CSL_AG__ENABLE_STD_FORMAT_SUPPORT] set to [true], but header <format> is missing.");
-#elif defined(CSL_AG__ENABLE_STD_FORMAT_SUPPORT) and CSL_AG__ENABLE_STD_FORMAT_SUPPORT
-
-#pragma message("[csl::ag] CSL_AG__ENABLE_STD_FORMAT_SUPPORT - enabled")
-
-#include <format>
-
-// std_formatter alias: normalises std::formatter's 2-param signature for use as
-// a template template parameter to ag_formatter_base.
-namespace csl::ag::io::details {
-    template <typename T, typename Char = char>
-    using std_formatter = std::formatter<T, Char>;
-
-    template <>
-    struct format_error_type<std_formatter> : std::type_identity<std::format_error>{};
-}
-
-// std::formatter for plain aggregate T - default (braced, flat) output.
-// Mirrors the fmtlib fmt::formatter<T> old path for ergonomic use without a view wrapper.
-template <csl::ag::concepts::aggregate T, typename Char>
-requires (not csl::ag::io::details::concepts::decorator<T>)
-and (not std::ranges::range<T>)
-struct std::formatter<T, Char>
-    : public csl::ag::io::details::ag_formatter_base<
-        csl::ag::io::details::std_formatter, T, Char
-    >
-{};
-
-// std_formattable (used upstream: not formatter detection)
-namespace csl::ag::io::details::type_traits {
-    template <typename T, typename Char>
-    struct is_std_formattable : std::bool_constant<std::formattable<T, Char>>{};
-    template <csl::ag::concepts::structured_bindable T, typename Char>
-    struct is_std_formattable<T, Char> {
-        constexpr static auto value = []<std::size_t ... indexes>(std::index_sequence<indexes...>){
-            return (true and ... and std::formattable<csl::ag::tuplelike::element_t<indexes, T>, Char>);
-        }(std::make_index_sequence<csl::ag::tuplelike::size_v<T>>{});
-    };
-    template <typename T, typename Char>
-    constexpr inline static auto is_std_formattable_v = is_std_formattable<T, Char>::value;
-}
-namespace csl::ag::io::details::concepts {
-
-    template <typename T, typename Char>
-    concept std_formattable = type_traits::is_std_formattable_v<T, Char>;
-}
-
-// std::formatter for formatted_view_t - composite structured_bindable T
-template <
-    csl::ag::concepts::structured_bindable T,
-    typename Char
->
-requires (not csl::ag::io::details::concepts::decorator<T>)
-struct std::formatter<
-    csl::ag::io::details::decorators::formatted_view_t<T>,
-    Char
-> : public csl::ag::io::details::ag_formatter_base<
-        csl::ag::io::details::std_formatter, T, Char
-    >
-{};
-
-// std::formatter for formatted_view_t - non-structured-bindable leaf T
-template <
-    typename T,
-    typename Char
->
-requires (not csl::ag::concepts::structured_bindable<T>)
-struct std::formatter<
-    csl::ag::io::details::decorators::formatted_view_t<T>,
-    Char
-> : public csl::ag::io::details::ag_formatter_base_leaf<
-        csl::ag::io::details::std_formatter, T, Char
-    >
-{};
-
-#endif // CSL_AG__ENABLE_STD_FORMAT_SUPPORT
-
-// Formatting: to_string
-//
-//  Backed by whichever formatting support is enabled: favor std::format, then fmtlib, then iostream.
-//  Usage: using namespace csl::ag::io;
-//      to_string(value)                            (default: braced, compact)
-//      to_string<indented>(value)                  (single option)
-//      to_string<indented | typenamed>(value)      (composed options)
-//      to_string(value | indented | typenamed)     (equivalent, view-based composition)
-#if defined(CSL_AG__ENABLE_STD_FORMAT_SUPPORT) and CSL_AG__ENABLE_STD_FORMAT_SUPPORT
-
-#include <string>
-
-namespace csl::ag::io {
-
-    template <format_options Options = format_options::none>
-    [[nodiscard]] auto to_string(csl::ag::concepts::structured_bindable auto const & value) -> std::string
-    requires (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
-    {
-        // NOTE: at default Options, format `value` directly so a user-defined formatter (if any) wins,
-        // exactly as the plain (option-less) operator<< / formatter<T> specializations do.
-        if constexpr (Options == format_options::none)
-            return std::format("{}", value);
-        else {
-            using value_type = std::remove_cvref_t<decltype(value)>;
-            return std::format("{}", details::decorators::formatted_view_t<value_type>{ .value = value, .options = Options });
-        }
-    }
-    template <typename T>
-    [[nodiscard]] auto to_string(details::decorators::formatted_view_t<T> const & view) -> std::string {
-        return std::format("{}", view);
-    }
-}
-
-#elif defined(CSL_AG__ENABLE_FMTLIB_SUPPORT) and CSL_AG__ENABLE_FMTLIB_SUPPORT
-
-#include <string>
-
-namespace csl::ag::io {
-    template <format_options Options = format_options::none>
-    [[nodiscard]] auto to_string(csl::ag::concepts::structured_bindable auto const & value) -> std::string
-    requires (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
-    {
-        // NOTE: at default Options, format `value` directly so a user-defined formatter (if any) wins,
-        // exactly as the plain (option-less) operator<< / formatter<T> specializations do.
-        if constexpr (Options == format_options::none)
-            return fmt::format("{}", value);
-        else {
-            using value_type = std::remove_cvref_t<decltype(value)>;
-            return fmt::format("{}", details::decorators::formatted_view_t<value_type>{ .value = value, .options = Options });
-        }
-    }
-    template <typename T>
-    [[nodiscard]] auto to_string(details::decorators::formatted_view_t<T> const & view) -> std::string {
-        return fmt::format("{}", view);
-    }
-}
-
-#elif defined(CSL_AG__ENABLE_IOSTREAM_SUPPORT) and CSL_AG__ENABLE_IOSTREAM_SUPPORT
-
-#include <string>
-
-namespace csl::ag::io {
-    template <format_options Options = format_options::none>
-    [[nodiscard]] auto to_string(csl::ag::concepts::structured_bindable auto const & value) -> std::string
-    requires (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
-    {
-        // NOTE: at default Options, stream `value` directly so a user-defined operator<< (if any) wins,
-        // exactly as the plain (option-less) operator<< does (overload resolution: exact match).
-        std::ostringstream ss;
-        if constexpr (Options == format_options::none)
-            ss << value;
-        else {
-            using value_type = std::remove_cvref_t<decltype(value)>;
-            ss << details::decorators::formatted_view_t<value_type>{ .value = value, .options = Options };
-        }
-        return std::move(ss).str();
-    }
-    template <typename T>
-    [[nodiscard]] auto to_string(details::decorators::formatted_view_t<T> const & view) -> std::string {
-        std::ostringstream ss;
-        ss << view;
-        return std::move(ss).str();
-    }
-}
-
-#endif
 
 namespace csl::ag::concepts {
     template <typename T>

--- a/libs/ag/includes/ag/csl/ag.hpp
+++ b/libs/ag/includes/ag/csl/ag.hpp
@@ -1181,7 +1181,7 @@ namespace csl::ag::tuplelike {
 //
 // Formatting backends are opt-in feature headers, include them consistently program-wide:
 //
-//  <csl/ag/formatting/format.hpp>      std::formatter support, csl::ag::io::to_string
+//  <csl/ag/formatting/format.hpp>      std::formatter support
 //  <csl/ag/formatting/fmt.hpp>         fmt::formatter support (fmtlib is provided by the consumer)
 //  <csl/ag/formatting/ostream.hpp>     operator<<(std::ostream &, ...) support
 //  <csl/ag/formatting/typeinfo.hpp>    compile-time type names for the typenamed option (csl::typeinfo-backed)

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/fmt.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/fmt.hpp
@@ -1,10 +1,41 @@
 #pragma once
-// cpp shelf library : aggregates utility - formatting: fmtlib support (opt-in feature header)
-// under MIT License - Copyright (c) 2021 Guillaume Dua "Guss"
-// https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
 
-// Provides fmt::formatter specializations for aggregates and formatted views (see operator|) via csl::ag::io.
-// fmtlib is provided by the consumer.
+/// @file
+/// @brief fmtlib support for structured bindables (opt-in feature header).
+///
+/// cpp shelf library : aggregates utility - formatting.
+///
+/// Provides `fmt::formatter` specializations for aggregates and formatted views (see operator|) via `csl::ag::io`.
+///
+/// @copyright Copyright (c) 2021 Guillaume Dua "Guss". MIT License.
+/// @see https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
+///
+/// @warning Adds blanket specializations: like @c <fmt/ranges.h>, include this header
+///          **consistently across the whole program** (ODR).
+///
+/// @par Requirements
+///      fmtlib (https://github.com/fmtlib/fmt) is provided by the consumer - this header does not fetch it.
+///      fmtlib >= 11 is required for the @c :n specifier.
+///
+/// @par Design
+///      - Blanket @c fmt::formatter<T> for any aggregate @c T (non-range, non-decorator) whose fields are all formattable.
+///      - Composable @c format_options selected via format-spec letters, or via the view-based @c operator| API - both are equivalent, and mixable:
+///         @code
+///         fmt::format("{}", value)                                       // default: braced, compact
+///         fmt::format("{:n}", value)                                     // flat, naked: no outer brackets or separator
+///         fmt::format("{}", value | csl::ag::io::indented)               // multiline, depth-indented
+///         fmt::format("{}", value | csl::ag::io::indexed)                // braced with [N] field indexes
+///         fmt::format("{}", value | csl::ag::io::typenamed)              // braced with TypeName: prefixes
+///         fmt::format("{:ixt}", value)                                   // spec letters compose too
+///         @endcode
+///      - Options propagate to nested structured_bindable fields (no_braces is outermost-only).
+///      - Leaf values consistent with fmtlib: char => 'x', bool => true/false, string => "...".
+///
+/// @par Usage
+///      @code
+///      using namespace csl::ag::io;
+///      fmt::println("{}", my_aggregate);
+///      @endcode
 
 #if not defined(CSL_AG__INCLUDED)
 #   include <csl/ag.hpp>

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/fmt.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/fmt.hpp
@@ -38,6 +38,9 @@
 ///      @endcode
 
 #if not defined(CSL_AG__INCLUDED)
+#   if not __has_include(<csl/ag.hpp>)
+#       error "[csl::ag] csl/ag/formatting/backend/fmt.hpp : missing <csl/ag.hpp>. This is an opt-in feature header: make <csl/ag.hpp> reachable, or #include it before this header (e.g. on Compiler Explorer, using its raw URL)."
+#   endif
 #   include <csl/ag.hpp>
 #endif
 

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/fmt.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/fmt.hpp
@@ -11,7 +11,7 @@
 #endif
 
 #if not __has_include(<fmt/format.h>)
-#   error "[csl::ag] csl/ag/formatting/fmt.hpp : missing <fmt/format.h>. Provide fmtlib in the build - https://github.com/fmtlib/fmt (on Compiler Explorer: Libraries -> add fmt)."
+#   error "[csl::ag] csl/ag/formatting/backend/fmt.hpp : missing <fmt/format.h>. Provide fmtlib in the build - https://github.com/fmtlib/fmt (on Compiler Explorer: Libraries -> add fmt)."
 #endif
 
 #include <fmt/ranges.h>

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/ostream.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/ostream.hpp
@@ -59,7 +59,10 @@ namespace csl::ag::io::details {
         os << v;
     };
 
-    static inline auto mode_index() noexcept -> int {
+    // NOTE: external linkage (inline, not static) is required here:
+    //       the local static must be the same object in every TU ([dcl.inline]/6),
+    //       or each TU would xalloc() its own iword slot.
+    inline auto mode_index() noexcept -> int {
         static const int index = std::ios_base::xalloc();
         return index;
     }
@@ -201,7 +204,7 @@ namespace csl::ag::io {
 
     /// \brief std::ostream formatting using formatted_view. Effectively bypasses iword.
     template <typename T>
-    static auto operator<<(std::ostream & os, details::decorators::formatted_view_t<T> const & view)
+    auto operator<<(std::ostream & os, details::decorators::formatted_view_t<T> const & view)
     -> std::ostream &
     {
         details::print(os, view.value, view.options, view.depth);

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/ostream.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/ostream.hpp
@@ -10,8 +10,8 @@
 /// @copyright Copyright (c) 2021 Guillaume Dua "Guss". MIT License.
 /// @see https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
 /// 
-/// @warning Prefer @c <csl/ag/formatting/format.hpp> (std::format) or
-///          @c <csl/ag/formatting/fmt.hpp> (fmtlib) over this when available.
+/// @warning Prefer @c <csl/ag/formatting/backend/std_format.hpp> (std::format) or
+///          @c <csl/ag/formatting/backend/fmt.hpp> (fmtlib) over this when available.
 /// 
 /// @par Compile-time cost
 ///      Including @c <ostream> is one of the heaviest standard headers, with

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/ostream.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/ostream.hpp
@@ -43,6 +43,9 @@
 ///      @endcode
 
 #if not defined(CSL_AG__INCLUDED)
+#   if not __has_include(<csl/ag.hpp>)
+#       error "[csl::ag] csl/ag/formatting/backend/ostream.hpp : missing <csl/ag.hpp>. This is an opt-in feature header: make <csl/ag.hpp> reachable, or #include it before this header (e.g. on Compiler Explorer, using its raw URL)."
+#   endif
 #   include <csl/ag.hpp>
 #endif
 

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/std_format.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/std_format.hpp
@@ -1,9 +1,39 @@
 #pragma once
-// cpp shelf library : aggregates utility - formatting: std::format support (opt-in feature header)
-// under MIT License - Copyright (c) 2021 Guillaume Dua "Guss"
-// https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
 
-// Provides std::formatter specializations for aggregates and formatted views (see operator|) via csl::ag::io.
+/// @file
+/// @brief std::format support for structured bindables (opt-in feature header).
+///
+/// cpp shelf library : aggregates utility - formatting.
+///
+/// Provides `std::formatter` specializations for aggregates and formatted views (see operator|) via `csl::ag::io`.
+///
+/// @copyright Copyright (c) 2021 Guillaume Dua "Guss". MIT License.
+/// @see https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
+///
+/// @warning Adds blanket specializations: like @c <fmt/ranges.h>, include this header
+///          **consistently across the whole program** (ODR).
+///
+/// @par Design
+///      - Blanket @c std::formatter<T> for any aggregate @c T (non-range, non-decorator) whose fields are all formattable.
+///      - Composable @c format_options selected via format-spec letters, or via the view-based @c operator| API - both are equivalent, and mixable:
+///         @code
+///         std::format("{}", value)                                       // default: braced, compact
+///         std::format("{:n}", value)                                     // flat, naked: no outer brackets or separator
+///         std::format("{}", value | csl::ag::io::indented)               // multiline, depth-indented
+///         std::format("{}", value | csl::ag::io::indexed)                // braced with [N] field indexes
+///         std::format("{}", value | csl::ag::io::typenamed)              // braced with TypeName: prefixes
+///         std::format("{:ixt}", value)                                   // spec letters compose too
+///         @endcode
+///      - Options propagate to nested structured_bindable fields (no_braces is outermost-only).
+///      - Leaf values consistent with fmtlib: char => 'x', bool => true/false, string => "...".
+///      - Tuple-like and range fields are formatted by this library's own machinery:
+///        no dependency on the STL's P2286 formatters (e.g. absent in libstdc++ 13).
+///
+/// @par Usage
+///      @code
+///      using namespace csl::ag::io;
+///      std::println("{}", my_aggregate);
+///      @endcode
 
 #if not defined(CSL_AG__INCLUDED)
 #   include <csl/ag.hpp>

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/std_format.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/std_format.hpp
@@ -36,6 +36,9 @@
 ///      @endcode
 
 #if not defined(CSL_AG__INCLUDED)
+#   if not __has_include(<csl/ag.hpp>)
+#       error "[csl::ag] csl/ag/formatting/backend/std_format.hpp : missing <csl/ag.hpp>. This is an opt-in feature header: make <csl/ag.hpp> reachable, or #include it before this header (e.g. on Compiler Explorer, using its raw URL)."
+#   endif
 #   include <csl/ag.hpp>
 #endif
 

--- a/libs/ag/includes/ag/csl/ag/formatting/backend/std_format.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/backend/std_format.hpp
@@ -10,7 +10,7 @@
 #endif
 
 #if not __has_include(<format>)
-#   error "csl/ag/formatting/format.hpp : missing <format> (std::format requires C++20)."
+#   error "csl/ag/formatting/backend/std_format.hpp : missing <format> (std::format requires C++20)."
 #endif
 
 #include <format>

--- a/libs/ag/includes/ag/csl/ag/formatting/fmt.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/fmt.hpp
@@ -1,0 +1,114 @@
+#pragma once
+// cpp shelf library : aggregates utility - formatting: fmtlib support (opt-in feature header)
+// under MIT License - Copyright (c) 2021 Guillaume Dua "Guss"
+// https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
+
+// Provides fmt::formatter specializations for aggregates and formatted views (see operator|) via csl::ag::io.
+// fmtlib is provided by the consumer.
+
+#if not defined(CSL_AG__INCLUDED)
+#   include <csl/ag.hpp>
+#endif
+
+#if not __has_include(<fmt/format.h>)
+#   error "[csl::ag] csl/ag/formatting/fmt.hpp : missing <fmt/format.h>. Provide fmtlib in the build - https://github.com/fmtlib/fmt (on Compiler Explorer: Libraries -> add fmt)."
+#endif
+
+#include <fmt/ranges.h>
+#include <fmt/compile.h>
+
+namespace csl::ag::io::type_traits {
+
+    // formatter_value_type
+    template <typename T>
+    struct formatter_value_type;
+    template <typename T, typename Char>
+    struct formatter_value_type<fmt::formatter<T, Char>> : std::type_identity<T>{};
+    template <typename T>
+    using formatter_value_type_t = formatter_value_type<T>::type;
+}
+
+namespace csl::ag::io::details {
+
+    /// \brief normalises fmt::formatter's 3-param signature (T, Char, SFINAE-Enable) to 2 params,
+    ///        so it can be passed as a template template parameter to ag_formatter_base.
+    ///        Reason: P0522 relaxed template template matching is not the default before Clang 19.
+    template <typename T, typename Char = char>
+    using fmt_formatter = fmt::formatter<T, Char>;
+
+    template <>
+    struct format_error_type<fmt_formatter> : std::type_identity<fmt::format_error>{};
+}
+
+namespace csl::ag::io::details::type_traits {
+
+    /// \brief used upstream, not formatter detection
+    template <typename T, typename Char>
+    struct is_fmt_formattable : fmt::is_formattable<T, Char>{};
+    template <csl::ag::concepts::structured_bindable T, typename Char>
+    struct is_fmt_formattable<T, Char> {
+        constexpr static auto value = []<std::size_t ... indexes>(std::index_sequence<indexes...>){
+            return (true and ... and is_fmt_formattable<csl::ag::tuplelike::element_t<indexes, T>, Char>::value);
+        }(std::make_index_sequence<csl::ag::tuplelike::size_v<T>>{});
+    };
+    template <typename T, typename Char>
+    constexpr inline static auto is_fmt_formattable_v = is_fmt_formattable<T, Char>::value;
+}
+namespace csl::ag::io::details::concepts {
+
+    /// \brief used upstream, not formatter detection
+    template <typename T, typename Char>
+    concept fmt_formattable = type_traits::is_fmt_formattable_v<T, Char>;
+}
+
+/// \brief fmt::formatter for plain aggregate T - default (braced, flat) output.
+///        WARNING: routes through ag_formatter_base, not fmt's native tuple_join_view formatter,
+///        per-element format-spec propagation (fmt feature enabler: FMT_TUPLE_JOIN_SPECIFIERS) is not used/available here.
+///        See simplification commit 000e7d2fb749bca03aadc80b22bad7e2f6d27f26
+template <csl::ag::concepts::aggregate T, typename Char>
+requires (not csl::ag::io::details::concepts::decorator<T>)
+and (not std::ranges::range<T>)
+class fmt::formatter<T, Char>
+    : public csl::ag::io::details::ag_formatter_base<
+        csl::ag::io::details::fmt_formatter, T, Char
+    >
+{};
+
+#pragma region // formatter<formatted_view_t> (composable options)
+
+namespace csl::ag::io::type_traits {
+    template <typename T, typename Char>
+    struct formatter_value_type<
+        fmt::formatter<csl::ag::io::details::decorators::formatted_view_t<T>, Char>
+    > : std::type_identity<T>{};
+}
+
+// fmt::formatter<formatted_view_t>: composite structured_bindable T
+template <
+    csl::ag::concepts::structured_bindable T,
+    typename Char
+>
+requires (not csl::ag::io::details::concepts::decorator<T>)
+and csl::ag::io::details::concepts::fmt_formattable<T, Char>
+class fmt::formatter<
+    csl::ag::io::details::decorators::formatted_view_t<T>,
+    Char
+> : public csl::ag::io::details::ag_formatter_base<
+        csl::ag::io::details::fmt_formatter, T, Char
+    >
+{};
+
+// fmt::formatter<formatted_view_t>: non-structured-bindable leaf T
+template <
+    typename T,
+    typename Char
+>
+requires (not csl::ag::concepts::structured_bindable<T>)
+class fmt::formatter<
+    csl::ag::io::details::decorators::formatted_view_t<T>,
+    Char
+> : public csl::ag::io::details::ag_formatter_base_leaf<
+        csl::ag::io::details::fmt_formatter, T, Char
+    >
+{};
+#pragma endregion

--- a/libs/ag/includes/ag/csl/ag/formatting/format.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/format.hpp
@@ -1,0 +1,116 @@
+#pragma once
+// cpp shelf library : aggregates utility - formatting: std::format support (opt-in feature header)
+// under MIT License - Copyright (c) 2021 Guillaume Dua "Guss"
+// https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
+
+// Provides std::formatter specializations for aggregates and formatted views (see operator|) via csl::ag::io, and csl::ag::io::to_string.
+
+#if not defined(CSL_AG__INCLUDED)
+#   include <csl/ag.hpp>
+#endif
+
+#if not __has_include(<format>)
+#   error "csl/ag/formatting/format.hpp : missing <format> (std::format requires C++20)."
+#endif
+
+#include <format>
+#include <string>
+
+namespace csl::ag::io::details {
+    template <>
+    struct format_error_type<std::formatter> : std::type_identity<std::format_error>{};
+}
+
+/// \brief std::formatter for plain aggregate: default (braced, flat) output.
+template <csl::ag::concepts::aggregate T, typename Char>
+requires (not csl::ag::io::details::concepts::decorator<T>)
+    and  (not std::ranges::range<T>)
+struct std::formatter<T, Char>
+    : public csl::ag::io::details::ag_formatter_base<
+        std::formatter, T, Char
+    >
+{};
+
+namespace csl::ag::io::details::type_traits {
+
+    /// \brief used upstream: not formatter detection
+    ///       Recurses through structured_bindable elements std::formattable is consulted at leaves only.
+    ///       NOTE: this library's view machinery formats those itself, so the STL's P2286 tuple-like/range formatters must NOT be required (e.g. absent in libstdc++ 13). 
+    template <typename T, typename Char>
+    struct is_std_formattable : std::bool_constant<std::formattable<T, Char>>{};
+    template <csl::ag::concepts::structured_bindable T, typename Char>
+    struct is_std_formattable<T, Char> {
+        constexpr static auto value = []<std::size_t ... indexes>(std::index_sequence<indexes...>){
+            return (true and ... and is_std_formattable<csl::ag::tuplelike::element_t<indexes, T>, Char>::value);
+        }(std::make_index_sequence<csl::ag::tuplelike::size_v<T>>{});
+    };
+    template <typename T, typename Char>
+    constexpr inline static auto is_std_formattable_v = is_std_formattable<T, Char>::value;
+}
+namespace csl::ag::io::details::concepts {
+
+    /// \brief used upstream: not formatter detection
+    template <typename T, typename Char>
+    concept std_formattable = type_traits::is_std_formattable_v<T, Char>;
+}
+
+// std::formatter<formatted_view_t>: composite structured_bindable T
+template <
+    csl::ag::concepts::structured_bindable T,
+    typename Char
+>
+requires (not csl::ag::io::details::concepts::decorator<T>)
+and csl::ag::io::details::concepts::std_formattable<T, Char>
+struct std::formatter<
+    csl::ag::io::details::decorators::formatted_view_t<T>,
+    Char
+> : public csl::ag::io::details::ag_formatter_base<
+        std::formatter, T, Char
+    >
+{};
+
+// std::formatter<formatted_view_t>: non-structured-bindable leaf T
+template <
+    typename T,
+    typename Char
+>
+requires (not csl::ag::concepts::structured_bindable<T>)
+struct std::formatter<
+    csl::ag::io::details::decorators::formatted_view_t<T>,
+    Char
+> : public csl::ag::io::details::ag_formatter_base_leaf<
+        std::formatter, T, Char
+    >
+{};
+
+/// \brief Formatting: to_string (std::format-backed)
+///        Usage:
+///
+///         using namespace csl::ag::io;
+///         to_string(value)                        (default: braced, compact)
+///         to_string<indented>(value)              (single option)
+///         to_string<indented | typenamed>(value)  (composed options)
+///         to_string(value | indented | typenamed) (equivalent, view-based composition)
+namespace csl::ag::io {
+
+    template <format_options Options = format_options::none>
+    [[nodiscard]] auto to_string(csl::ag::concepts::structured_bindable auto const & value) -> std::string
+    requires (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
+    {
+        // NOTE: at default Options, format `value` directly so a user-defined formatter (if any) wins,
+        // exactly as the plain (option-less) operator<< / formatter<T> specializations do.
+        if constexpr (Options == format_options::none)
+            return std::format("{}", value);
+        else {
+            using value_type = std::remove_cvref_t<decltype(value)>;
+            return std::format("{}", details::decorators::formatted_view_t<value_type>{
+                .value = value,
+                .options = Options
+            });
+        }
+    }
+    template <typename T>
+    [[nodiscard]] auto to_string(details::decorators::formatted_view_t<T> const & view) -> std::string {
+        return std::format("{}", view);
+    }
+}

--- a/libs/ag/includes/ag/csl/ag/formatting/format.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/format.hpp
@@ -3,7 +3,7 @@
 // under MIT License - Copyright (c) 2021 Guillaume Dua "Guss"
 // https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
 
-// Provides std::formatter specializations for aggregates and formatted views (see operator|) via csl::ag::io, and csl::ag::io::to_string.
+// Provides std::formatter specializations for aggregates and formatted views (see operator|) via csl::ag::io.
 
 #if not defined(CSL_AG__INCLUDED)
 #   include <csl/ag.hpp>
@@ -14,7 +14,6 @@
 #endif
 
 #include <format>
-#include <string>
 
 namespace csl::ag::io::details {
     template <>
@@ -54,6 +53,7 @@ namespace csl::ag::io::details::concepts {
     concept std_formattable = type_traits::is_std_formattable_v<T, Char>;
 }
 
+// NOLINTBEGIN(cert-dcl58-cpp) - std::formatter is a CPO
 // std::formatter<formatted_view_t>: composite structured_bindable T
 template <
     csl::ag::concepts::structured_bindable T,
@@ -82,35 +82,4 @@ struct std::formatter<
         std::formatter, T, Char
     >
 {};
-
-/// \brief Formatting: to_string (std::format-backed)
-///        Usage:
-///
-///         using namespace csl::ag::io;
-///         to_string(value)                        (default: braced, compact)
-///         to_string<indented>(value)              (single option)
-///         to_string<indented | typenamed>(value)  (composed options)
-///         to_string(value | indented | typenamed) (equivalent, view-based composition)
-namespace csl::ag::io {
-
-    template <format_options Options = format_options::none>
-    [[nodiscard]] auto to_string(csl::ag::concepts::structured_bindable auto const & value) -> std::string
-    requires (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
-    {
-        // NOTE: at default Options, format `value` directly so a user-defined formatter (if any) wins,
-        // exactly as the plain (option-less) operator<< / formatter<T> specializations do.
-        if constexpr (Options == format_options::none)
-            return std::format("{}", value);
-        else {
-            using value_type = std::remove_cvref_t<decltype(value)>;
-            return std::format("{}", details::decorators::formatted_view_t<value_type>{
-                .value = value,
-                .options = Options
-            });
-        }
-    }
-    template <typename T>
-    [[nodiscard]] auto to_string(details::decorators::formatted_view_t<T> const & view) -> std::string {
-        return std::format("{}", view);
-    }
-}
+// NOLINTEND(cert-dcl58-cpp)

--- a/libs/ag/includes/ag/csl/ag/formatting/ostream.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/ostream.hpp
@@ -1,0 +1,226 @@
+#pragma once
+
+/// @file
+/// @brief std::ostream support for structured bindables (opt-in feature header).
+/// 
+/// cpp shelf library : aggregates utility - formatting.
+/// 
+/// Provides `operator<<(std::ostream &, structured_bindable)` via `csl::ag::io`.
+/// 
+/// @copyright Copyright (c) 2021 Guillaume Dua "Guss". MIT License.
+/// @see https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
+/// 
+/// @warning Prefer @c <csl/ag/formatting/format.hpp> (std::format) or
+///          @c <csl/ag/formatting/fmt.hpp> (fmtlib) over this when available.
+/// 
+/// @par Compile-time cost
+///      Including @c <ostream> is one of the heaviest standard headers, with
+///      significantly slower build times.
+/// 
+/// @par Runtime cost
+///      @c std::ios_base::xalloc() and @c std::ios_base::iword() are used to store
+///      the active options on the stream. Both involve a global mutex and can be a
+///      bottleneck in hot paths or multi-threaded code.
+/// 
+/// @par Design
+///      - Composable @c format_options bitmask selected via IO manipulators
+///        (one-shot, reset after each print) or via the view-based @c operator| API (bypasses iword entirely):
+///         @code
+///         os << value                                                    // default: braced, compact
+///         os << csl::ag::io::no_braces << value                          // flat, naked: no outer brackets or separator
+///         os << csl::ag::io::indented  << value                          // multiline, depth-indented
+///         os << csl::ag::io::indexed   << value                          // braced with [N] field indexes
+///         os << csl::ag::io::typenamed << value                          // braced with TypeName: prefixes
+///         os << (value | csl::ag::io::indented | csl::ag::io::indexed)   // view-based, composable
+///         @endcode
+///      - Options propagate to nested structured_bindable fields (no_braces is outermost-only).
+///      - Leaf values consistent with fmtlib: char => 'x', bool => true/false, string => "...".
+/// 
+/// @par Usage
+///      @code
+///      using namespace csl::ag::io;
+///      std::cout << my_aggregate;
+///      @endcode
+
+#if not defined(CSL_AG__INCLUDED)
+#   include <csl/ag.hpp>
+#endif
+
+#include <ostream>
+
+#define csl_fwd(...) static_cast<decltype(__VA_ARGS__) &&>(__VA_ARGS__) // NOLINT(cppcoreguidelines-macro-usage)
+
+namespace csl::ag::io::details {
+
+    /// \brief T has an operator<<(std::ostream &, T) reachable WITHOUT csl::ag::io in scope.
+    // This prevents this library operator<< from satisfying the concept (depend on self).
+    template <typename T>
+    concept ostream_formattable = requires(std::ostream & os, const std::remove_cvref_t<T> & v) {
+        os << v;
+    };
+
+    static inline auto mode_index() noexcept -> int {
+        static const int index = std::ios_base::xalloc();
+        return index;
+    }
+
+    inline void write_indent(std::ostream & os, std::size_t depth) {
+        constexpr std::size_t max_depth = 32;
+        static constexpr auto buf =
+            []<std::size_t... Is>(std::index_sequence<Is...>) {
+                return std::array<char, sizeof...(Is)>{ ((void)Is, ' ')... };
+            }(std::make_index_sequence<max_depth * style::indentation_width>{});
+        os.write(buf.data(), static_cast<std::streamsize>(std::min(max_depth, depth) * style::indentation_width));
+    }
+
+    struct format_options_view {
+
+        bool is_indented;
+        bool is_no_braces;
+        bool is_indexed;
+        bool is_typenamed;
+        format_options nested; // no_braces is outermost-only
+
+        constexpr explicit format_options_view(format_options options) noexcept
+            : is_indented  { bool(options & format_options::indented)  }
+            , is_no_braces { bool(options & format_options::no_braces) }
+            , is_indexed   { bool(options & format_options::indexed)   }
+            , is_typenamed { bool(options & format_options::typenamed) }
+            , nested       { options & ~format_options::no_braces      }
+        {}
+    };
+
+    // NOTE: Forward declaration: print and print_field_value are mutually recursive.
+    template <csl::ag::concepts::structured_bindable T>
+    void print(std::ostream & os, T && value, format_options options, std::size_t depth)
+    requires (not std::is_array_v<std::remove_cvref_t<T>>);
+
+    /// \brief print_field_value: write one field value of type T to an ostream value.
+    // Quoting is consistent with fmtlib: char => 'x', bool => true/false, string => "...".
+    // WARNING(Known limitation) range-like and tuple-like field values are not recursively pretty-printed;
+    //   they require a user-provided operator<< or they hit the static_assert.
+    // TODO: get rid of such a limitation, for consistency sake ?
+    template <typename T>
+    void print_field_value(std::ostream & os, T && value, format_options options, std::size_t depth) {
+        using type = std::remove_cvref_t<T>;
+        if constexpr (std::is_same_v<type, bool>)
+            os << (value ? "true" : "false");
+        else if constexpr (std::is_same_v<type, char>)
+            os << '\'' << value << '\'';
+        else if constexpr (std::is_same_v<type, std::string_view> or std::is_same_v<type, std::string>)
+            os << '"' << value << '"';
+        else if constexpr (ostream_formattable<type>)
+            os << value;
+        else if constexpr (csl::ag::concepts::structured_bindable<type> and not std::is_array_v<type>)
+            print(os, csl_fwd(value), options, depth);
+        else
+            static_assert(false, "[csl::ag::io] field type is not printable: provide operator<<(std::ostream &, T)");
+    }
+
+    template <csl::ag::concepts::structured_bindable T>
+    void print(std::ostream & os, T && value, format_options options, std::size_t depth)
+    requires (not std::is_array_v<std::remove_cvref_t<T>>)
+    {
+        using type = std::remove_cvref_t<T>;
+        constexpr auto size = csl::ag::tuplelike::size_v<type>;
+
+        const auto opt = format_options_view{ options };
+
+        if (not opt.is_no_braces) os << style::opening_bracket<type>();
+        if (opt.is_indented)      os << '\n';
+
+        [&]<std::size_t ... indexes>(std::index_sequence<indexes...>) {
+            ([&] {
+                
+                if constexpr (indexes > 0) {
+                    if (not opt.is_no_braces)       os << ',';
+                    if (opt.is_indented)            os << '\n';
+                    else if (not opt.is_no_braces)  os << ' ';
+                }
+                
+                if (opt.is_indented)
+                    write_indent(os, depth + 1);
+
+                if (opt.is_indexed)
+                    os << '[' << indexes << "] ";
+                
+                if (opt.is_typenamed) {
+                    using field_type = csl::ag::tuplelike::element_t<indexes, type>;
+                    os << type_name_v<field_type> << ": ";
+                }
+                print_field_value(
+                    os,
+                    csl::ag::tuplelike::get<indexes>(csl_fwd(value)),
+                    opt.nested,
+                    depth + 1
+                );
+            }(), ...);
+        }(std::make_index_sequence<size>{});
+
+        if (opt.is_indented){
+            os << '\n';
+            write_indent(os, depth);
+        }
+        if (not opt.is_no_braces)
+            os << style::closing_bracket<type>();
+    }
+}
+
+namespace csl::ag::io {
+
+    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - indented
+    inline auto operator<<(std::ostream & os, indented_t) -> std::ostream & {
+        os.iword(details::mode_index()) |= std::to_underlying(format_options::indented);
+        return os;
+    }
+    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - no_braces
+    inline auto operator<<(std::ostream & os, no_braces_t) -> std::ostream & {
+        os.iword(details::mode_index()) |= std::to_underlying(format_options::no_braces);
+        return os;
+    }
+    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - indexed
+    inline auto operator<<(std::ostream & os, indexed_t) -> std::ostream & {
+        os.iword(details::mode_index()) |= std::to_underlying(format_options::indexed);
+        return os;
+    }
+    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - typenamed
+    inline auto operator<<(std::ostream & os, typenamed_t) -> std::ostream & {
+        os.iword(details::mode_index()) |= std::to_underlying(format_options::typenamed);
+        return os;
+    }
+    /// \brief Composable std::ostream manipulator (one-shot, reset after use) - precomputed bitmask
+    ///        Mirrors the tag-based manipulators above, for a `format_options` combined ahead of time, e.g.
+    ///        @code
+    ///        constexpr auto options = indented | indexed | typenamed;
+    ///        os << options << value;
+    ///        @endcode
+    inline auto operator<<(std::ostream & os, format_options options) -> std::ostream & {
+        os.iword(details::mode_index()) |= std::to_underlying(options);
+        return os;
+    }
+
+    /// \brief std::ostream formatting using formatted_view. Effectively bypasses iword.
+    template <typename T>
+    static auto operator<<(std::ostream & os, details::decorators::formatted_view_t<T> const & view)
+    -> std::ostream &
+    {
+        details::print(os, view.value, view.options, view.depth);
+        return os;
+    }
+
+    /// \brief Format a structured_bindable into an std::ostream, using iword options (one-shot) and prints.
+    /// User-defined operator<<(std::ostream &, T) wins via overload resolution (exact match).
+    auto operator<<(std::ostream & os, const csl::ag::concepts::structured_bindable auto & value)
+    -> std::ostream &
+    requires (not std::is_array_v<std::remove_cvref_t<decltype(value)>>)
+    and (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
+    {
+        auto options = static_cast<format_options>(os.iword(details::mode_index()));
+        os.iword(details::mode_index()) = 0; // reset (one-shot semantics)
+        details::print(os, value, options, 0);
+        return os;
+    }
+
+}
+
+#undef csl_fwd

--- a/libs/ag/includes/ag/csl/ag/formatting/typeinfo.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/typeinfo.hpp
@@ -17,6 +17,9 @@
 /// @note Like every feature header, include it consistently program-wide.
 
 #if not defined(CSL_AG__INCLUDED)
+#   if not __has_include(<csl/ag.hpp>)
+#       error "[csl::ag] csl/ag/formatting/typeinfo.hpp : missing <csl/ag.hpp>. This is an opt-in feature header: make <csl/ag.hpp> reachable, or #include it before this header (e.g. on Compiler Explorer, using its raw URL)."
+#   endif
 #   include <csl/ag.hpp>
 #endif
 

--- a/libs/ag/includes/ag/csl/ag/formatting/typeinfo.hpp
+++ b/libs/ag/includes/ag/csl/ag/formatting/typeinfo.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+/// @file
+/// @brief csl::typeinfo support for the @c typenamed formatting option (opt-in feature header).
+///
+/// cpp shelf library : aggregates utility - formatting.
+///
+/// @copyright Copyright (c) 2021 Guillaume Dua "Guss". MIT License.
+/// @see https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
+///
+/// @details
+/// Backs the @c typenamed formatting option (@c csl::ag::io::type_name customization trait) with csl::typeinfo:
+/// compile-time, demangled type names, instead of the @c <typeindex> runtime fallback.
+///
+/// Orthogonal to csl::ag formatting backends: enhances whichever formatting feature headers are included, if any.
+///
+/// @note Like every feature header, include it consistently program-wide.
+
+#if not defined(CSL_AG__INCLUDED)
+#   include <csl/ag.hpp>
+#endif
+
+#if not defined(CSL_TYPEINFO__INCLUDED) and __has_include(<csl/typeinfo.hpp>)
+#   include <csl/typeinfo.hpp>
+#endif
+#if not defined(CSL_TYPEINFO__INCLUDED)
+#   error "[csl::ag] csl/ag/formatting/typeinfo.hpp : missing <csl/typeinfo.hpp> (csl::typeinfo). Make it reachable, or #include it before this header (e.g. on Compiler Explorer, using its raw URL)."
+#endif
+
+namespace csl::ag::io {
+
+    template <typename T>
+    requires requires {
+        { csl::typeinfo::type_name<T>::value } -> std::convertible_to<std::string_view>;
+    }
+    struct type_name<T> : csl::typeinfo::type_name<T>{};
+}

--- a/libs/ag/tests/CMakeLists.txt
+++ b/libs/ag/tests/CMakeLists.txt
@@ -95,8 +95,9 @@ endfunction()
 #     - no_typeinfo: <typeindex> runtime fallback (deterministic, implementation-defined names)
 #
 #   Outside the matrix:
-#     - formatting_coexistence.cpp:   every feature header in one TU
-#     - odr_mixed_{bridge,plain}.cpp: one binary, two TUs, only one includes the bridge
+#     - formatting_coexistence.cpp:      every feature header in one TU
+#     - odr_mixed_{bridge,plain}.cpp:    one binary, two TUs, only one includes the bridge
+#     - ostream_iword_cross_tu*.cpp:     one binary, two TUs, iword slot must be program-wide
 # ---------------------------------------------------------------------------------------------
 add_custom_target(${PROJECT_NAME}_${component_name}_build_all_tests)
 
@@ -149,8 +150,7 @@ foreach(bitfields IN ITEMS 0 1)
 
 endforeach()
 
-# Every formatting feature header in a single TU: backends must coexist (each specializes
-# a different framework's entity)
+# Every formatting feature header in a single TU: backends must coexist (each specializes a different framework's entity)
 csl_ag_make_test_target(
     NAME        formatting_coexistence
     SOURCE      ${CMAKE_CURRENT_SOURCE_DIR}/formatting_coexistence.cpp
@@ -160,12 +160,21 @@ csl_ag_make_test_target(
 )
 add_dependencies(${PROJECT_NAME}_${component_name}_build_all_tests ${target_name})
 
-# ODR sanity (fmt-style feature-header contract): two TUs, only one includes the typeinfo
-# bridge, each formats different types - must link and behave deterministically
+# ODR sanity (fmt-style feature-header contract):
+# - two TUs, only one includes the typeinfo bridge, each formats different types - must link and behave deterministically
 csl_ag_make_test_target(
     NAME        odr_mixed
     SOURCE      ${CMAKE_CURRENT_SOURCE_DIR}/odr_mixed_bridge.cpp ${CMAKE_CURRENT_SOURCE_DIR}/odr_mixed_plain.cpp
     EXTRA_LIBS  ${PROJECT_NAME}::typeinfo
+    RESULT      target_name
+)
+add_dependencies(${PROJECT_NAME}_${component_name}_build_all_tests ${target_name})
+
+# iword cross-TU contract: two TUs
+# - a manipulator applied in one TU must be seen by a print in the other (details::mode_index() must yield one xalloc slot program-wide)
+csl_ag_make_test_target(
+    NAME        ostream_iword_cross_tu
+    SOURCE      ${CMAKE_CURRENT_SOURCE_DIR}/ostream_iword_cross_tu.cpp ${CMAKE_CURRENT_SOURCE_DIR}/ostream_iword_cross_tu_remote.cpp
     RESULT      target_name
 )
 add_dependencies(${PROJECT_NAME}_${component_name}_build_all_tests ${target_name})

--- a/libs/ag/tests/CMakeLists.txt
+++ b/libs/ag/tests/CMakeLists.txt
@@ -21,14 +21,14 @@ endif()
 #
 # Named arguments:
 #	NAME        - logical name used in the target name (e.g. "compile_time")
-#   SOURCE      - single source file
+#   SOURCE      - one or more source files
 #   DEFINITIONS - list of FORCE_* compile definitions (e.g. FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=1)
 #   EXTRA_LIBS  - additional link targets
 #   RESULT      - optional variable to receive the generated target name
 # ---------------------------------------------------------------------------
 function(csl_ag_make_test_target)
 
-    cmake_parse_arguments(arg "" "NAME;SOURCE;RESULT" "DEFINITIONS;EXTRA_LIBS" ${ARGN})
+    cmake_parse_arguments(arg "" "NAME;RESULT" "SOURCE;DEFINITIONS;EXTRA_LIBS" ${ARGN})
 
     foreach(lib IN LISTS arg_EXTRA_LIBS)
         if(NOT TARGET ${lib})
@@ -45,11 +45,19 @@ function(csl_ag_make_test_target)
         elseif(def MATCHES "FORCE_CSL_AG__ENABLE_(.+)_SUPPORT=1")
             string(TOLOWER "${CMAKE_MATCH_1}" part)
             list(APPEND suffix_parts "${part}")
+        elseif(def MATCHES "CSL_AG_TEST__WITH_TYPEINFO=0")
+            list(APPEND suffix_parts "no_typeinfo")
+        elseif(def MATCHES "CSL_AG_TEST__WITH_TYPEINFO=1")
+            list(APPEND suffix_parts "typeinfo")
         endif()
     endforeach()
     list(JOIN suffix_parts "." suffix)
 
-    set(target_name "test.${PROJECT_NAME}_${component_name}.${arg_NAME}.${suffix}")
+    if (suffix)
+        set(target_name "test.${PROJECT_NAME}_${component_name}.${arg_NAME}.${suffix}")
+    else()
+        set(target_name "test.${PROJECT_NAME}_${component_name}.${arg_NAME}")
+    endif()
 
     add_executable(${target_name} ${arg_SOURCE})
     target_compile_definitions(${target_name} PRIVATE ${arg_DEFINITIONS})
@@ -75,16 +83,21 @@ function(csl_ag_make_test_target)
     endif()
 endfunction()
 
-# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------
 # Test matrix: foreach bitfield in {0, 1}, foreach inject_csl_typeinfo in {with, without}
 #
 #   - compile_time.cpp  	    (core static_assert suite, unaffected by inject_csl_typeinfo)
-#   - <formatting>_support.cpp  (specific formatting support: iostream, fmtlib, std::format)
+#   - <formatting>_support.cpp  (one formatting feature header each: ostream, fmt, std::format)
 #
-#   inject_csl_typeinfo covers both csl::ag formatting code paths:
-#     - with_typeinfo: csl::typeinfo is linked, typenamed views use compile-time demangling
-#     - no_typeinfo:   csl::typeinfo is not linked, <typeindex>-based implementation is not even tested (yet)
-# ---------------------------------------------------------------------------
+#   inject_csl_typeinfo covers both `typenamed` code paths - CSL_AG_TEST__WITH_TYPEINFO gates
+#   the <csl/ag/formatting/typeinfo.hpp> include in the test sources:
+#     - typeinfo:    bridge included + csl::typeinfo linked, compile-time demangled names
+#     - no_typeinfo: <typeindex> runtime fallback (deterministic, implementation-defined names)
+#
+#   Outside the matrix:
+#     - formatting_coexistence.cpp:   every feature header in one TU
+#     - odr_mixed_{bridge,plain}.cpp: one binary, two TUs, only one includes the bridge
+# ---------------------------------------------------------------------------------------------
 add_custom_target(${PROJECT_NAME}_${component_name}_build_all_tests)
 
 foreach(bitfields IN ITEMS 0 1)
@@ -107,27 +120,27 @@ foreach(bitfields IN ITEMS 0 1)
         endif()
 
         csl_ag_make_test_target(
-            NAME            iostream_support_${inject_csl_typeinfo}
+            NAME            iostream_support
             SOURCE          ${CMAKE_CURRENT_SOURCE_DIR}/iostream_support.cpp
-            DEFINITIONS     FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=${bitfields}
+            DEFINITIONS     FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=${bitfields} CSL_AG_TEST__WITH_TYPEINFO=${inject_csl_typeinfo}
             EXTRA_LIBS      ${_maybe_csl_typeinfo}
             RESULT          target_name
         )
         add_dependencies(${PROJECT_NAME}_${component_name}_build_all_tests ${target_name})
 
         csl_ag_make_test_target(
-            NAME            fmtlib_support_${inject_csl_typeinfo}
+            NAME            fmtlib_support
             SOURCE          ${CMAKE_CURRENT_SOURCE_DIR}/fmtlib_support.cpp
-            DEFINITIONS     FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=${bitfields}
+            DEFINITIONS     FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=${bitfields} CSL_AG_TEST__WITH_TYPEINFO=${inject_csl_typeinfo}
             EXTRA_LIBS      fmt::fmt-header-only ${_maybe_csl_typeinfo}
             RESULT          target_name
         )
         add_dependencies(${PROJECT_NAME}_${component_name}_build_all_tests ${target_name})
 
         csl_ag_make_test_target(
-            NAME            std_format_support_${inject_csl_typeinfo}
+            NAME            std_format_support
             SOURCE          ${CMAKE_CURRENT_SOURCE_DIR}/std_format_support.cpp
-            DEFINITIONS     FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=${bitfields}
+            DEFINITIONS     FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=${bitfields} CSL_AG_TEST__WITH_TYPEINFO=${inject_csl_typeinfo}
             EXTRA_LIBS      ${_maybe_csl_typeinfo}
             RESULT          target_name
         )
@@ -135,3 +148,24 @@ foreach(bitfields IN ITEMS 0 1)
     endforeach()
 
 endforeach()
+
+# Every formatting feature header in a single TU: backends must coexist (each specializes
+# a different framework's entity; to_string ships with format.hpp only)
+csl_ag_make_test_target(
+    NAME        formatting_coexistence
+    SOURCE      ${CMAKE_CURRENT_SOURCE_DIR}/formatting_coexistence.cpp
+    DEFINITIONS FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT=0 CSL_AG_TEST__WITH_TYPEINFO=1
+    EXTRA_LIBS  fmt::fmt-header-only ${PROJECT_NAME}::typeinfo
+    RESULT      target_name
+)
+add_dependencies(${PROJECT_NAME}_${component_name}_build_all_tests ${target_name})
+
+# ODR sanity (fmt-style feature-header contract): two TUs, only one includes the typeinfo
+# bridge, each formats different types - must link and behave deterministically
+csl_ag_make_test_target(
+    NAME        odr_mixed
+    SOURCE      ${CMAKE_CURRENT_SOURCE_DIR}/odr_mixed_bridge.cpp ${CMAKE_CURRENT_SOURCE_DIR}/odr_mixed_plain.cpp
+    EXTRA_LIBS  ${PROJECT_NAME}::typeinfo
+    RESULT      target_name
+)
+add_dependencies(${PROJECT_NAME}_${component_name}_build_all_tests ${target_name})

--- a/libs/ag/tests/CMakeLists.txt
+++ b/libs/ag/tests/CMakeLists.txt
@@ -150,7 +150,7 @@ foreach(bitfields IN ITEMS 0 1)
 endforeach()
 
 # Every formatting feature header in a single TU: backends must coexist (each specializes
-# a different framework's entity; to_string ships with format.hpp only)
+# a different framework's entity)
 csl_ag_make_test_target(
     NAME        formatting_coexistence
     SOURCE      ${CMAKE_CURRENT_SOURCE_DIR}/formatting_coexistence.cpp

--- a/libs/ag/tests/fmtlib_support.cpp
+++ b/libs/ag/tests/fmtlib_support.cpp
@@ -38,8 +38,7 @@ namespace tests::concepts::fmt_formattable {
 
     // wired into fmt::formatter<formatted_view_t<T>> (composite view):
     // a non-formattable field disables the specialization, so fmt::is_formattable answers false.
-    // NOTE: the field must be a non-aggregate - an (even empty) aggregate is formattable
-    //       through this library's own blanket fmt::formatter
+    // NOTE: the field must be a non-aggregate - an (even empty) aggregate is formattable through this library's own blanket fmt::formatter
     struct not_formattable_field { explicit not_formattable_field() = default; };
     struct with_not_formattable_field { not_formattable_field f; };
     static_assert(not concepts::fmt_formattable<with_not_formattable_field, char>);

--- a/libs/ag/tests/fmtlib_support.cpp
+++ b/libs/ag/tests/fmtlib_support.cpp
@@ -62,6 +62,4 @@ namespace {
     }
 } // namespace
 
-// to_string is std::format-backed, ships with <csl/ag/formatting/format.hpp> only
-#define CSL_AG_TEST__HAS_TO_STRING 0
 #include <tests/ag/format_test_cases.hpp>

--- a/libs/ag/tests/fmtlib_support.cpp
+++ b/libs/ag/tests/fmtlib_support.cpp
@@ -6,9 +6,11 @@
 #  define CSL_AG__ENABLE_BITFIELDS_SUPPORT true
 #endif
 
-#define CSL_AG__ENABLE_FMTLIB_SUPPORT true
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/fmt.hpp>
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
+#   include <csl/ag/formatting/typeinfo.hpp>
+#endif
 #include <tests/types.hpp>
 #include <tests/ag/typeinfo_specializations.hpp>
 
@@ -33,6 +35,15 @@ namespace tests::concepts::fmt_formattable {
     static_assert(concepts::fmt_formattable<std::vector<types::field_1>, char>);
     static_assert(concepts::fmt_formattable<std::tuple<int>, char>);
     static_assert(concepts::fmt_formattable<std::array<int, 3>, char>);
+
+    // wired into fmt::formatter<formatted_view_t<T>> (composite view):
+    // a non-formattable field disables the specialization, so fmt::is_formattable answers false.
+    // NOTE: the field must be a non-aggregate - an (even empty) aggregate is formattable
+    //       through this library's own blanket fmt::formatter
+    struct not_formattable_field { explicit not_formattable_field() = default; };
+    struct with_not_formattable_field { not_formattable_field f; };
+    static_assert(not concepts::fmt_formattable<with_not_formattable_field, char>);
+    static_assert(not fmt::is_formattable<csl::ag::io::details::decorators::formatted_view_t<with_not_formattable_field>, char>::value);
 }
 
 namespace {
@@ -51,4 +62,6 @@ namespace {
     }
 } // namespace
 
+// to_string is std::format-backed, ships with <csl/ag/formatting/format.hpp> only
+#define CSL_AG_TEST__HAS_TO_STRING 0
 #include <tests/ag/format_test_cases.hpp>

--- a/libs/ag/tests/fmtlib_support.cpp
+++ b/libs/ag/tests/fmtlib_support.cpp
@@ -7,7 +7,7 @@
 #endif
 
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/fmt.hpp>
+#include <csl/ag/formatting/backend/fmt.hpp>
 #if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 #   include <csl/ag/formatting/typeinfo.hpp>
 #endif

--- a/libs/ag/tests/formatting_coexistence.cpp
+++ b/libs/ag/tests/formatting_coexistence.cpp
@@ -8,9 +8,9 @@
 
 // Every formatting feature header in one TU: backends must coexist
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>
-#include <csl/ag/formatting/fmt.hpp>
-#include <csl/ag/formatting/ostream.hpp>
+#include <csl/ag/formatting/backend/std_format.hpp>
+#include <csl/ag/formatting/backend/fmt.hpp>
+#include <csl/ag/formatting/backend/ostream.hpp>
 #if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 #   include <csl/ag/formatting/typeinfo.hpp>
 #endif

--- a/libs/ag/tests/formatting_coexistence.cpp
+++ b/libs/ag/tests/formatting_coexistence.cpp
@@ -34,7 +34,6 @@ TEST_CASE("all formatting backends coexist in one TU", "[ag][formatting][coexist
 
     CHECK(std::format("{}", value) == expected);
     CHECK(fmt::format("{}", value) == expected);
-    CHECK(csl::ag::io::to_string(value) == expected);
     {
         std::ostringstream ss;
         using namespace csl::ag::io;
@@ -51,7 +50,6 @@ TEST_CASE("all formatting backends coexist in one TU - composed views", "[ag][fo
 
     CHECK(std::format("{}", value | indexed | typenamed) == expected);
     CHECK(fmt::format("{}", value | indexed | typenamed) == expected);
-    CHECK(to_string(value | indexed | typenamed) == expected);
     {
         std::ostringstream ss;
         ss << (value | indexed | typenamed);

--- a/libs/ag/tests/formatting_coexistence.cpp
+++ b/libs/ag/tests/formatting_coexistence.cpp
@@ -1,0 +1,63 @@
+#if not defined(FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT)
+#  error "FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT is not set"
+#endif
+#undef  CSL_AG__ENABLE_BITFIELDS_SUPPORT
+#if FORCE_CSL_AG__ENABLE_BITFIELDS_SUPPORT
+#  define CSL_AG__ENABLE_BITFIELDS_SUPPORT true
+#endif
+
+// Every formatting feature header in one TU: backends must coexist
+#include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/fmt.hpp>
+#include <csl/ag/formatting/ostream.hpp>
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
+#   include <csl/ag/formatting/typeinfo.hpp>
+#endif
+#include <tests/types.hpp>
+
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include <catch2/catch_test_macros.hpp>
+
+// NOLINTBEGIN(*-avoid-do-while)
+// NOLINTBEGIN(*-avoid-magic-numbers)
+
+namespace types = test::ag::types;
+
+TEST_CASE("all formatting backends coexist in one TU", "[ag][formatting][coexistence]") {
+
+    constexpr auto value = types::field_2{ .i = 123, .c = 'A' };
+    constexpr std::string_view expected = "{123, 'A'}";
+
+    CHECK(std::format("{}", value) == expected);
+    CHECK(fmt::format("{}", value) == expected);
+    CHECK(csl::ag::io::to_string(value) == expected);
+    {
+        std::ostringstream ss;
+        using namespace csl::ag::io;
+        ss << value;
+        CHECK(ss.str() == expected);
+    }
+}
+
+TEST_CASE("all formatting backends coexist in one TU - composed views", "[ag][formatting][coexistence]") {
+
+    using namespace csl::ag::io;
+    constexpr auto value = types::field_2{ .i = 123, .c = 'A' };
+    constexpr std::string_view expected = "{[0] int: 123, [1] char: 'A'}";
+
+    CHECK(std::format("{}", value | indexed | typenamed) == expected);
+    CHECK(fmt::format("{}", value | indexed | typenamed) == expected);
+    CHECK(to_string(value | indexed | typenamed) == expected);
+    {
+        std::ostringstream ss;
+        ss << (value | indexed | typenamed);
+        CHECK(ss.str() == expected);
+    }
+}
+
+// NOLINTEND(*-avoid-magic-numbers)
+// NOLINTEND(*-avoid-do-while)

--- a/libs/ag/tests/includes/tests/ag/format_test_cases.hpp
+++ b/libs/ag/tests/includes/tests/ag/format_test_cases.hpp
@@ -4,6 +4,7 @@
 #include <format>
 #include <string>
 #include <tuple>
+#include <typeindex>
 #include <vector>
 
 #include <catch2/catch_template_test_macros.hpp>
@@ -24,7 +25,7 @@ namespace {
         constexpr bool bitfields_enabled = false;
 #endif
 
-#if __has_include(<csl/typeinfo.hpp>)
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
         constexpr bool typeinfo_linked = true;
 #else
         constexpr bool typeinfo_linked = false;
@@ -115,7 +116,7 @@ TEMPLATE_TEST_CASE(":x" + implementation::name_suffix() + "", implementation::ta
     CHECK(implementation::format("{:x}", f::value) == f::indexed_expected);
 }
 
-#if __has_include(<csl/typeinfo.hpp>)
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 TEMPLATE_TEST_CASE(":t" + implementation::name_suffix() + "", implementation::tags(),
     types::field_1,
     types::field_2,
@@ -186,7 +187,7 @@ TEMPLATE_TEST_CASE("indexed" + implementation::name_suffix() + "", implementatio
     CHECK(implementation::format("{}", f::value | csl::ag::io::indexed) == f::indexed_expected);
 }
 
-#if __has_include(<csl/typeinfo.hpp>)
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 TEMPLATE_TEST_CASE("typenamed" + implementation::name_suffix() + "", implementation::tags(),
     types::field_1,
     types::field_2,
@@ -255,6 +256,23 @@ TEMPLATE_TEST_CASE("view composition" + implementation::name_suffix() + "", impl
 }
 #endif
 
+#if not (defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO)
+// Fallback contract: without the typeinfo bridge, type_name is std::type_index(typeid(T)).name()
+// (implementation-defined, possibly mangled - but deterministic).
+TEMPLATE_TEST_CASE("typenamed: <typeindex> runtime fallback" + implementation::name_suffix() + "", implementation::tags(),
+    types::field_2
+) {
+    using f = fixture<TestType>;
+    const auto expected = std::format("{{{}: 123, {}: 'A'}}",
+        std::type_index(typeid(int)).name(),
+        std::type_index(typeid(char)).name()
+    );
+    CHECK(implementation::format("{}", f::value | csl::ag::io::typenamed) == expected);
+    CHECK(implementation::format("{:t}", f::value) == expected);
+}
+#endif
+
+#if defined(CSL_AG_TEST__HAS_TO_STRING) and CSL_AG_TEST__HAS_TO_STRING
 TEMPLATE_TEST_CASE("csl::ag::io::to_string default output" + implementation::name_suffix() + "", implementation::tags(),
     types::field_1,
     types::field_2,
@@ -267,7 +285,7 @@ TEMPLATE_TEST_CASE("csl::ag::io::to_string default output" + implementation::nam
     CHECK(csl::ag::io::to_string(f::value) == f::default_expected);
 }
 
-#if __has_include(<csl/typeinfo.hpp>)
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 TEMPLATE_TEST_CASE("csl::ag::io::to_string composed view output" + implementation::name_suffix() + "", implementation::tags(),
     types::field_1,
     types::field_2,
@@ -300,6 +318,7 @@ TEMPLATE_TEST_CASE("csl::ag::io::to_string composed NTTP output" + implementatio
     );
 }
 #endif
+#endif // CSL_AG_TEST__HAS_TO_STRING
 
 // NOLINTEND(*-avoid-magic-numbers)
 // NOLINTEND(*cert-err58-cpp)

--- a/libs/ag/tests/includes/tests/ag/format_test_cases.hpp
+++ b/libs/ag/tests/includes/tests/ag/format_test_cases.hpp
@@ -87,6 +87,8 @@ TEMPLATE_TEST_CASE(":n" + implementation::name_suffix() + "", implementation::ta
     types::field_everything
 ) {
     using f = fixture<TestType>;
+    CHECK(implementation::format("{:n}", f::value | csl::ag::io::no_braces) == f::no_braces_expected);
+    CHECK(implementation::format("{}", f::value | csl::ag::io::no_braces) == f::no_braces_expected);
     CHECK(implementation::format("{:n}", f::value) == f::no_braces_expected);
 }
 
@@ -100,6 +102,7 @@ TEMPLATE_TEST_CASE(":i" + implementation::name_suffix() + "", implementation::ta
 ) {
     using f = fixture<TestType>;
     CHECK(implementation::format("{:i}", f::value | csl::ag::io::indented) == f::indented_expected);
+    CHECK(implementation::format("{}", f::value | csl::ag::io::indented) == f::indented_expected);
     CHECK(implementation::format("{:i}", f::value) == f::indented_expected);
 }
 
@@ -113,6 +116,7 @@ TEMPLATE_TEST_CASE(":x" + implementation::name_suffix() + "", implementation::ta
 ) {
     using f = fixture<TestType>;
     CHECK(implementation::format("{:x}", f::value | csl::ag::io::indexed) == f::indexed_expected);
+    CHECK(implementation::format("{}", f::value | csl::ag::io::indexed) == f::indexed_expected);
     CHECK(implementation::format("{:x}", f::value) == f::indexed_expected);
 }
 
@@ -127,6 +131,7 @@ TEMPLATE_TEST_CASE(":t" + implementation::name_suffix() + "", implementation::ta
 ) {
     using f = fixture<TestType>;
     CHECK(implementation::format("{:t}", f::value | csl::ag::io::typenamed) == f::typenamed_expected);
+    CHECK(implementation::format("{}", f::value | csl::ag::io::typenamed) == f::typenamed_expected);
     CHECK(implementation::format("{:t}", f::value) == f::typenamed_expected);
 }
 
@@ -142,6 +147,10 @@ TEMPLATE_TEST_CASE(":ixt" + implementation::name_suffix() + "", implementation::
 
     CHECK(
         implementation::format("{:ixt}", f::value | csl::ag::io::indented | csl::ag::io::indexed | csl::ag::io::typenamed)
+        == f::indented_indexed_typenamed_expected
+    );
+    CHECK(
+        implementation::format("{}", f::value | csl::ag::io::indented | csl::ag::io::indexed | csl::ag::io::typenamed)
         == f::indented_indexed_typenamed_expected
     );
     CHECK(implementation::format("{:ixt}", f::value) == f::indented_indexed_typenamed_expected);
@@ -271,54 +280,6 @@ TEMPLATE_TEST_CASE("typenamed: <typeindex> runtime fallback" + implementation::n
     CHECK(implementation::format("{:t}", f::value) == expected);
 }
 #endif
-
-#if defined(CSL_AG_TEST__HAS_TO_STRING) and CSL_AG_TEST__HAS_TO_STRING
-TEMPLATE_TEST_CASE("csl::ag::io::to_string default output" + implementation::name_suffix() + "", implementation::tags(),
-    types::field_1,
-    types::field_2,
-    types::field_3_nested,
-    types::field_3_nested_tuplelike,
-    types::field_4_nested_range,
-    types::field_everything
-) {
-    using f = fixture<TestType>;
-    CHECK(csl::ag::io::to_string(f::value) == f::default_expected);
-}
-
-#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
-TEMPLATE_TEST_CASE("csl::ag::io::to_string composed view output" + implementation::name_suffix() + "", implementation::tags(),
-    types::field_1,
-    types::field_2,
-    types::field_3_nested,
-    types::field_3_nested_tuplelike,
-    types::field_4_nested_range,
-    types::field_everything
-) {
-    using namespace csl::ag::io;
-    using f = fixture<TestType>;
-    CHECK(
-        to_string(f::value | indented | indexed | typenamed)
-        == f::indented_indexed_typenamed_expected
-    );
-}
-
-TEMPLATE_TEST_CASE("csl::ag::io::to_string composed NTTP output" + implementation::name_suffix() + "", implementation::tags(),
-    types::field_1,
-    types::field_2,
-    types::field_3_nested,
-    types::field_3_nested_tuplelike,
-    types::field_4_nested_range,
-    types::field_everything
-) {
-    using namespace csl::ag::io;
-    using f = fixture<TestType>;
-    CHECK(
-        to_string<indented | indexed | typenamed>(f::value)
-        == f::indented_indexed_typenamed_expected
-    );
-}
-#endif
-#endif // CSL_AG_TEST__HAS_TO_STRING
 
 // NOLINTEND(*-avoid-magic-numbers)
 // NOLINTEND(*cert-err58-cpp)

--- a/libs/ag/tests/includes/tests/ag/typeinfo_specializations.hpp
+++ b/libs/ag/tests/includes/tests/ag/typeinfo_specializations.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-// Must be included after <csl/ag.hpp> with a format macro defined.
+// Must be included after <csl/ag/formatting/typeinfo.hpp>.
 
 // QUICK-FIX: consistent typeinfo outputs
-#if __has_include(<csl/typeinfo.hpp>)
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 #include <array>
 #include <string_view>
 #include <tuple>
-namespace csl::ag::io::details {
+namespace csl::ag::io {
 
     template <>
     struct type_name<std::string_view> {

--- a/libs/ag/tests/iostream_support.cpp
+++ b/libs/ag/tests/iostream_support.cpp
@@ -7,7 +7,7 @@
 #endif
 
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/ostream.hpp>
+#include <csl/ag/formatting/backend/ostream.hpp>
 #if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 #   include <csl/ag/formatting/typeinfo.hpp>
 #endif

--- a/libs/ag/tests/iostream_support.cpp
+++ b/libs/ag/tests/iostream_support.cpp
@@ -77,7 +77,6 @@ namespace {
         return value;
     }
 
-    // to_string is std::format-backed (ships with <csl/ag/formatting/format.hpp>): stream instead
     [[nodiscard]] auto stream_out(auto const & value) -> std::string {
         using namespace csl::ag::io;
         std::ostringstream ss;

--- a/libs/ag/tests/iostream_support.cpp
+++ b/libs/ag/tests/iostream_support.cpp
@@ -6,17 +6,18 @@
 #  define CSL_AG__ENABLE_BITFIELDS_SUPPORT true
 #endif
 
-#define CSL_AG__ENABLE_IOSTREAM_SUPPORT 1
-#define CSL_AG__ENABLE_FMTLIB_SUPPORT 0
-#define CSL_AG__ENABLE_STD_FORMAT_SUPPORT 0
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/ostream.hpp>
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
+#   include <csl/ag/formatting/typeinfo.hpp>
+#endif
 #include <tests/types.hpp>
 #include <tests/ag/typeinfo_specializations.hpp>
 
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <typeindex>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -64,7 +65,7 @@ namespace {
     constexpr bool bitfields_enabled = false;
 #endif
 
-#if __has_include(<csl/typeinfo.hpp>)
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
     constexpr bool typeinfo_linked = true;
 #else
     constexpr bool typeinfo_linked = false;
@@ -74,6 +75,14 @@ namespace {
         static const std::string value = std::string(" [FORMATTING=iostream] [BITFIELDS=") + (bitfields_enabled ? "ON" : "OFF")
             + "] [TYPEINFO=" + (typeinfo_linked ? "ON" : "OFF") + "]";
         return value;
+    }
+
+    // to_string is std::format-backed (ships with <csl/ag/formatting/format.hpp>): stream instead
+    [[nodiscard]] auto stream_out(auto const & value) -> std::string {
+        using namespace csl::ag::io;
+        std::ostringstream ss;
+        ss << value;
+        return std::move(ss).str();
     }
 
     template <typename T>
@@ -438,7 +447,7 @@ TEMPLATE_TEST_CASE("csl::ag::io default (braced) output" + name_suffix() + "",
 {
     using namespace csl::ag::io;
     using f = fixture<TestType>;
-    CHECK(to_string(f::value) == f::default_expected);
+    CHECK(stream_out(f::value) == f::default_expected);
 }
 
 TEMPLATE_TEST_CASE("csl::ag::io no_braces output" + name_suffix() + "",
@@ -452,7 +461,7 @@ TEMPLATE_TEST_CASE("csl::ag::io no_braces output" + name_suffix() + "",
 {
     using namespace csl::ag::io;
     using f = fixture<TestType>;
-    CHECK(to_string<no_braces>(f::value) == f::no_braces_expected);
+    CHECK(stream_out(f::value | no_braces) == f::no_braces_expected);
 }
 
 TEMPLATE_TEST_CASE("csl::ag::io indented output" + name_suffix() + "",
@@ -466,7 +475,7 @@ TEMPLATE_TEST_CASE("csl::ag::io indented output" + name_suffix() + "",
 {
     using namespace csl::ag::io;
     using f = fixture<TestType>;
-    CHECK(to_string<indented>(f::value) == f::indented_expected);
+    CHECK(stream_out(f::value | indented) == f::indented_expected);
 }
 
 TEST_CASE("csl::ag::io user operator<< preferred for ostream_formattable types" + name_suffix() + "",
@@ -475,7 +484,7 @@ TEST_CASE("csl::ag::io user operator<< preferred for ostream_formattable types" 
     using namespace csl::ag::io;
     // printable_t: structured_bindable AND has user-defined operator<<.
     // - exact-match overload wins over our constrained template.
-    CHECK(to_string(printable_t{42}) == "printable:42");
+    CHECK(stream_out(printable_t{42}) == "printable:42");
 }
 
 TEST_CASE("csl::ag::io ostream_formattable field: user operator<< used directly" + name_suffix() + "",
@@ -484,7 +493,7 @@ TEST_CASE("csl::ag::io ostream_formattable field: user operator<< used directly"
     using namespace csl::ag::io;
     // with_printable_field: { printable_t p; int x; }
     // Field p is ostream_formattable - user's operator<< is used (not recursive print).
-    auto out = to_string(with_printable_field{.p = {42}, .x = 7}); // NOLINT(*-magic-numbers)
+    auto out = stream_out(with_printable_field{.p = {42}, .x = 7}); // NOLINT(*-magic-numbers)
     CHECK(out == "{printable:42, 7}");
 }
 
@@ -492,8 +501,8 @@ TEST_CASE("csl::ag::io empty aggregate" + name_suffix() + "",
           "[ag][iostream]")
 {
     using namespace csl::ag::io;
-    CHECK(to_string(types::empty{})            == "{}");
-    CHECK(to_string<no_braces>(types::empty{}) == "");
+    CHECK(stream_out(types::empty{})             == "{}");
+    CHECK(stream_out(types::empty{} | no_braces) == "");
 }
 
 TEMPLATE_TEST_CASE("csl::ag::io indexed output" + name_suffix() + "",
@@ -507,10 +516,10 @@ TEMPLATE_TEST_CASE("csl::ag::io indexed output" + name_suffix() + "",
 {
     using namespace csl::ag::io;
     using f = fixture<TestType>;
-    CHECK(to_string<indexed>(f::value) == f::indexed_expected);
+    CHECK(stream_out(f::value | indexed) == f::indexed_expected);
 }
 
-#if __has_include(<csl/typeinfo.hpp>)
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 TEMPLATE_TEST_CASE("csl::ag::io typenamed output" + name_suffix() + "",
                    "[ag][iostream]",
                    types::field_1,
@@ -522,7 +531,7 @@ TEMPLATE_TEST_CASE("csl::ag::io typenamed output" + name_suffix() + "",
 {
     using namespace csl::ag::io;
     using f = fixture<TestType>;
-    CHECK(to_string<typenamed>(f::value) == f::typenamed_expected);
+    CHECK(stream_out(f::value | typenamed) == f::typenamed_expected);
 }
 
 TEMPLATE_TEST_CASE("csl::ag::io indented+indexed+typenamed output" + name_suffix() + "",
@@ -536,10 +545,10 @@ TEMPLATE_TEST_CASE("csl::ag::io indented+indexed+typenamed output" + name_suffix
 {
     using namespace csl::ag::io;
     using f = fixture<TestType>;
-    CHECK(to_string<indented | indexed | typenamed>(f::value) == f::indented_indexed_typenamed_expected);
+    CHECK(stream_out(f::value | (indented | indexed | typenamed)) == f::indented_indexed_typenamed_expected);
 }
 
-TEMPLATE_TEST_CASE("csl::ag::io::to_string composed view output" + name_suffix() + "",
+TEMPLATE_TEST_CASE("csl::ag::io composed view output" + name_suffix() + "",
                    "[ag][iostream]",
                    types::field_1,
                    types::field_2,
@@ -550,10 +559,23 @@ TEMPLATE_TEST_CASE("csl::ag::io::to_string composed view output" + name_suffix()
 {
     using namespace csl::ag::io;
     using f = fixture<TestType>;
-    CHECK(to_string(f::value | indented | indexed | typenamed) == f::indented_indexed_typenamed_expected);
+    CHECK(stream_out(f::value | indented | indexed | typenamed) == f::indented_indexed_typenamed_expected);
 }
 #endif
 
+#if not (defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO)
+// Fallback contract: without the typeinfo bridge, type_name is std::type_index(typeid(T)).name()
+// (implementation-defined, possibly mangled - but deterministic).
+TEST_CASE("csl::ag::io typenamed <typeindex> runtime fallback" + name_suffix() + "",
+          "[ag][iostream]")
+{
+    using namespace csl::ag::io;
+    using f = fixture<types::field_2>;
+    const auto expected = "{" + std::string{ std::type_index(typeid(int)).name() } + ": 123, "
+        + std::string{ std::type_index(typeid(char)).name() } + ": 'A'}";
+    CHECK(stream_out(f::value | typenamed) == expected);
+}
+#endif
 
 // NOLINTEND(*-avoid-magic-numbers)
 // NOLINTEND(*cert-err58-cpp)

--- a/libs/ag/tests/odr_mixed_bridge.cpp
+++ b/libs/ag/tests/odr_mixed_bridge.cpp
@@ -2,7 +2,7 @@
 // this TU includes the typeinfo bridge, the sibling TU (odr_mixed_plain.cpp) does not - each formats *different* types.
 // The resulting binary must link and behave deterministically.
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/backend/std_format.hpp>
 #include <csl/ag/formatting/typeinfo.hpp>
 
 #include <format>

--- a/libs/ag/tests/odr_mixed_bridge.cpp
+++ b/libs/ag/tests/odr_mixed_bridge.cpp
@@ -5,6 +5,8 @@
 #include <csl/ag/formatting/format.hpp>
 #include <csl/ag/formatting/typeinfo.hpp>
 
+#include <format>
+
 #include <catch2/catch_test_macros.hpp>
 
 // NOLINTBEGIN(*-avoid-do-while)
@@ -18,7 +20,7 @@ TEST_CASE("odr-mixed: bridged TU - typenamed uses csl::typeinfo", "[ag][formatti
     using namespace csl::ag::io;
 
     // NOTE: int demangling seems stable across compilers
-    CHECK(to_string<typenamed>(test::ag::odr::bridged{ .i = 42 }) == "{int: 42}");
+    CHECK(std::format("{}", test::ag::odr::bridged{ .i = 42 } | typenamed) == "{int: 42}");
 }
 
 // NOLINTEND(*-avoid-magic-numbers)

--- a/libs/ag/tests/odr_mixed_bridge.cpp
+++ b/libs/ag/tests/odr_mixed_bridge.cpp
@@ -1,0 +1,25 @@
+// ODR sanity (fmt-style feature-header contract):
+// this TU includes the typeinfo bridge, the sibling TU (odr_mixed_plain.cpp) does not - each formats *different* types.
+// The resulting binary must link and behave deterministically.
+#include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/typeinfo.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+// NOLINTBEGIN(*-avoid-do-while)
+// NOLINTBEGIN(*-avoid-magic-numbers)
+
+namespace test::ag::odr {
+    struct bridged { int i; };
+}
+
+TEST_CASE("odr-mixed: bridged TU - typenamed uses csl::typeinfo", "[ag][formatting][odr]") {
+    using namespace csl::ag::io;
+
+    // NOTE: int demangling seems stable across compilers
+    CHECK(to_string<typenamed>(test::ag::odr::bridged{ .i = 42 }) == "{int: 42}");
+}
+
+// NOLINTEND(*-avoid-magic-numbers)
+// NOLINTEND(*-avoid-do-while)

--- a/libs/ag/tests/odr_mixed_plain.cpp
+++ b/libs/ag/tests/odr_mixed_plain.cpp
@@ -18,7 +18,7 @@ namespace test::ag::odr {
 TEST_CASE("odr-mixed: plain TU - typenamed uses the <typeindex> fallback", "[ag][formatting][odr]") {
     using namespace csl::ag::io;
     const auto expected = std::format("{{{}: 'A'}}", std::type_index(typeid(char)).name());
-    CHECK(to_string<typenamed>(test::ag::odr::plain{ .c = 'A' }) == expected);
+    CHECK(std::format("{}", test::ag::odr::plain{ .c = 'A' } | typenamed) == expected);
 }
 
 // NOLINTEND(*-avoid-magic-numbers)

--- a/libs/ag/tests/odr_mixed_plain.cpp
+++ b/libs/ag/tests/odr_mixed_plain.cpp
@@ -11,6 +11,10 @@
 // NOLINTBEGIN(*-avoid-do-while)
 // NOLINTBEGIN(*-avoid-magic-numbers)
 
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
+# error "CSL_AG_TEST__WITH_TYPEINFO must not be defined for this test"
+#endif
+
 namespace test::ag::odr {
     struct plain { char c; };
 }

--- a/libs/ag/tests/odr_mixed_plain.cpp
+++ b/libs/ag/tests/odr_mixed_plain.cpp
@@ -1,7 +1,7 @@
 // ODR sanity (fmt-style feature-header contract):
 // this TU does NOT include the typeinfo bridge - see odr_mixed_bridge.cpp for the rationale and the contract being verified.
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/backend/std_format.hpp>
 
 #include <format>
 #include <typeindex>

--- a/libs/ag/tests/odr_mixed_plain.cpp
+++ b/libs/ag/tests/odr_mixed_plain.cpp
@@ -1,0 +1,25 @@
+// ODR sanity (fmt-style feature-header contract):
+// this TU does NOT include the typeinfo bridge - see odr_mixed_bridge.cpp for the rationale and the contract being verified.
+#include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>
+
+#include <format>
+#include <typeindex>
+
+#include <catch2/catch_test_macros.hpp>
+
+// NOLINTBEGIN(*-avoid-do-while)
+// NOLINTBEGIN(*-avoid-magic-numbers)
+
+namespace test::ag::odr {
+    struct plain { char c; };
+}
+
+TEST_CASE("odr-mixed: plain TU - typenamed uses the <typeindex> fallback", "[ag][formatting][odr]") {
+    using namespace csl::ag::io;
+    const auto expected = std::format("{{{}: 'A'}}", std::type_index(typeid(char)).name());
+    CHECK(to_string<typenamed>(test::ag::odr::plain{ .c = 'A' }) == expected);
+}
+
+// NOLINTEND(*-avoid-magic-numbers)
+// NOLINTEND(*-avoid-do-while)

--- a/libs/ag/tests/ostream_iword_cross_tu.cpp
+++ b/libs/ag/tests/ostream_iword_cross_tu.cpp
@@ -1,0 +1,42 @@
+// iword cross-TU contract: details::mode_index() must return the same xalloc slot in every TU,
+// so manipulator state applied in one TU is seen by prints in another.
+// (regression: an internal-linkage - static - mode_index gave each TU its own slot)
+#include <csl/ag.hpp>
+#include <csl/ag/formatting/backend/ostream.hpp>
+
+#include <sstream>
+
+#include <catch2/catch_test_macros.hpp>
+
+// NOLINTBEGIN(*-avoid-do-while)
+// NOLINTBEGIN(*-avoid-magic-numbers)
+
+namespace test::ag::cross_tu {
+    // defined in ostream_iword_cross_tu_remote.cpp
+    auto iword_slot() -> int;
+    void set_indented(std::ostream & os);
+}
+
+namespace {
+    struct A { int i; char c; };
+}
+
+TEST_CASE("ostream: iword slot is program-wide", "[ag][formatting][iostream][odr]") {
+    CHECK(test::ag::cross_tu::iword_slot() == csl::ag::io::details::mode_index());
+}
+
+TEST_CASE("ostream: manipulator applied in another TU", "[ag][formatting][iostream][odr]") {
+    std::ostringstream os;
+    test::ag::cross_tu::set_indented(os);
+
+    using namespace csl::ag::io;
+    os << A{ .i = 42, .c = 'x' };
+    CHECK(os.str() ==
+R"({
+    42,
+    'x'
+})");
+}
+
+// NOLINTEND(*-avoid-magic-numbers)
+// NOLINTEND(*-avoid-do-while)

--- a/libs/ag/tests/ostream_iword_cross_tu_remote.cpp
+++ b/libs/ag/tests/ostream_iword_cross_tu_remote.cpp
@@ -1,0 +1,10 @@
+// iword cross-TU contract - remote TU: see ostream_iword_cross_tu.cpp
+#include <csl/ag.hpp>
+#include <csl/ag/formatting/backend/ostream.hpp>
+
+#include <ostream>
+
+namespace test::ag::cross_tu {
+    auto iword_slot() -> int { return csl::ag::io::details::mode_index(); }
+    void set_indented(std::ostream & os) { os << csl::ag::io::indented; }
+}

--- a/libs/ag/tests/std_format_support.cpp
+++ b/libs/ag/tests/std_format_support.cpp
@@ -6,9 +6,11 @@
 #  define CSL_AG__ENABLE_BITFIELDS_SUPPORT true
 #endif
 
-#define CSL_AG__ENABLE_STD_FORMAT_SUPPORT true
-
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>
+#if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
+#   include <csl/ag/formatting/typeinfo.hpp>
+#endif
 #include <tests/types.hpp>
 #include <tests/ag/typeinfo_specializations.hpp>
 
@@ -16,11 +18,7 @@
 
 namespace types = test::ag::types;
 
-// csl::ag::io::details::concepts::std_formattable: see csl/ag.hpp.
-//
-// NOTE: std::formatter<tuple-like> is standardized in C++23 (P2286),
-// but since some compiler's libstdc++ doesn't implement it yet,
-// coverage cannot mirror tests::concepts::fmt_formattable (fmtlib_support.cpp) one-for-one here.
+// csl::ag::io::details::concepts::std_formattable: see csl/ag/formatting/format.hpp.
 namespace tests::concepts::std_formattable {
 
     namespace concepts = csl::ag::io::details::concepts;
@@ -28,9 +26,27 @@ namespace tests::concepts::std_formattable {
     static_assert(concepts::std_formattable<types::field_1, char>);
     static_assert(concepts::std_formattable<types::field_2, char>);
     static_assert(concepts::std_formattable<types::field_3_nested, char>);
+    // P2286-independent: this library's view machinery formats tuple-like/range elements itself,
+    // so these hold even when the STL lacks std::formatter<tuple-like> (e.g. libstdc++ 13)
+    static_assert(concepts::std_formattable<types::field_3_nested_tuplelike, char>);
+    static_assert(concepts::std_formattable<types::field_4_nested_range, char>);
+    static_assert(concepts::std_formattable<types::field_everything, char>);
 
     static_assert(concepts::std_formattable<int, char>);
     static_assert(concepts::std_formattable<std::string, char>);
+
+    // wired into std::formatter<formatted_view_t<T>> (composite view):
+    // a non-formattable field disables the specialization, so std::formattable answers false.
+    // NOTE: the field must be a non-aggregate - an (even empty) aggregate is formattable
+    //       through this library's own blanket std::formatter
+    struct not_formattable_field { explicit not_formattable_field() = default; };
+    struct with_not_formattable_field { not_formattable_field f; };
+    static_assert(not concepts::std_formattable<with_not_formattable_field, char>);
+    static_assert(not std::formattable<csl::ag::io::details::decorators::formatted_view_t<with_not_formattable_field>, char>);
+
+    // recursion: the non-formattable leaf is reached through a nested aggregate
+    struct nested_with_not_formattable_field { with_not_formattable_field w; int i; };
+    static_assert(not concepts::std_formattable<nested_with_not_formattable_field, char>);
 }
 
 namespace {
@@ -49,4 +65,5 @@ namespace {
     }
 } // namespace
 
+#define CSL_AG_TEST__HAS_TO_STRING 1
 #include <tests/ag/format_test_cases.hpp>

--- a/libs/ag/tests/std_format_support.cpp
+++ b/libs/ag/tests/std_format_support.cpp
@@ -26,8 +26,8 @@ namespace tests::concepts::std_formattable {
     static_assert(concepts::std_formattable<types::field_1, char>);
     static_assert(concepts::std_formattable<types::field_2, char>);
     static_assert(concepts::std_formattable<types::field_3_nested, char>);
-    // P2286-independent: this library's view machinery formats tuple-like/range elements itself,
-    // so these hold even when the STL lacks std::formatter<tuple-like> (e.g. libstdc++ 13)
+    // NOTE(P2286-independent) this librarys formats tuple-like/range elements itself,
+    // so these hold even when the STL lacks std::formatter<tuple-like> (e.g. libstdc++-13)
     static_assert(concepts::std_formattable<types::field_3_nested_tuplelike, char>);
     static_assert(concepts::std_formattable<types::field_4_nested_range, char>);
     static_assert(concepts::std_formattable<types::field_everything, char>);
@@ -35,18 +35,21 @@ namespace tests::concepts::std_formattable {
     static_assert(concepts::std_formattable<int, char>);
     static_assert(concepts::std_formattable<std::string, char>);
 
-    // wired into std::formatter<formatted_view_t<T>> (composite view):
-    // a non-formattable field disables the specialization, so std::formattable answers false.
-    // NOTE: the field must be a non-aggregate - an (even empty) aggregate is formattable
-    //       through this library's own blanket std::formatter
-    struct not_formattable_field { explicit not_formattable_field() = default; };
-    struct with_not_formattable_field { not_formattable_field f; };
-    static_assert(not concepts::std_formattable<with_not_formattable_field, char>);
-    static_assert(not std::formattable<csl::ag::io::details::decorators::formatted_view_t<with_not_formattable_field>, char>);
+    // empty types are valid aggregates
+    struct empty{};
+    struct nested_empty{ empty e; int i; };
+    static_assert(concepts::std_formattable<empty, char>);
+    static_assert(concepts::std_formattable<nested_empty, char>);
+    static_assert(std::formattable<csl::ag::io::details::decorators::formatted_view_t<empty>, char>);
+    static_assert(std::formattable<csl::ag::io::details::decorators::formatted_view_t<nested_empty>, char>);
 
-    // recursion: the non-formattable leaf is reached through a nested aggregate
-    struct nested_with_not_formattable_field { with_not_formattable_field w; int i; };
-    static_assert(not concepts::std_formattable<nested_with_not_formattable_field, char>);
+    // non-aggregates types are not supported
+    struct not_formattable { explicit not_formattable() = default; };
+    struct nested_not_formattable { not_formattable f; };
+    static_assert(not concepts::std_formattable<not_formattable, char>);
+    static_assert(not concepts::std_formattable<nested_not_formattable, char>);
+    static_assert(not std::formattable<csl::ag::io::details::decorators::formatted_view_t<not_formattable>, char>);
+    static_assert(not std::formattable<csl::ag::io::details::decorators::formatted_view_t<nested_not_formattable>, char>);
 }
 
 namespace {
@@ -65,5 +68,4 @@ namespace {
     }
 } // namespace
 
-#define CSL_AG_TEST__HAS_TO_STRING 1
 #include <tests/ag/format_test_cases.hpp>

--- a/libs/ag/tests/std_format_support.cpp
+++ b/libs/ag/tests/std_format_support.cpp
@@ -7,7 +7,7 @@
 #endif
 
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/backend/std_format.hpp>
 #if defined(CSL_AG_TEST__WITH_TYPEINFO) and CSL_AG_TEST__WITH_TYPEINFO
 #   include <csl/ag/formatting/typeinfo.hpp>
 #endif
@@ -18,7 +18,7 @@
 
 namespace types = test::ag::types;
 
-// csl::ag::io::details::concepts::std_formattable: see csl/ag/formatting/format.hpp.
+// csl::ag::io::details::concepts::std_formattable: see csl/ag/formatting/backend/std_format.hpp.
 namespace tests::concepts::std_formattable {
 
     namespace concepts = csl::ag::io::details::concepts;

--- a/libs/ensure/includes/ensure/csl/ensure.hpp
+++ b/libs/ensure/includes/ensure/csl/ensure.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+// NOTE: Detectable by other csl libraries/headers (via #if defined(...)), even when not reachable through __has_include (e.g. Compiler Explorer raw-URL includes).
+#define CSL_ENSURE__INCLUDED
+
 #if __cplusplus >= 202002L
 # include <csl/cxx_20/ensure.hpp>
 #elif __cplusplus >= 201703L

--- a/libs/functional/includes/functional/csl/functional.hpp
+++ b/libs/functional/includes/functional/csl/functional.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+// NOTE: Detectable by other csl libraries/headers (via #if defined(...)), even when not reachable through __has_include (e.g. Compiler Explorer raw-URL includes).
+#define CSL_FUNCTIONAL__INCLUDED
+
 #if not __cplusplus >= 201703L
 # error "csl/functional.hpp requires C++20"
 #endif

--- a/libs/mp/includes/mp/csl/mp.hpp
+++ b/libs/mp/includes/mp/csl/mp.hpp
@@ -4,6 +4,9 @@
 // under MIT License - Copyright (c) 2021-2025 Guillaume Dua
 // see https://github.com/GuillaumeDua/CppShelf/blob/main/LICENSE
 
+// NOTE: Detectable by other csl libraries/headers (via #if defined(...)), even when not reachable through __has_include (e.g. Compiler Explorer raw-URL includes).
+#define CSL_MP__INCLUDED
+
 // About [tuple-like]:
 //
 //  A given tuple-like type T is considered valid if the following concepts evaluate to true

--- a/libs/wf/includes/wf/csl/wf.hpp
+++ b/libs/wf/includes/wf/csl/wf.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+// NOTE: Detectable by other csl libraries/headers (via #if defined(...)), even when not reachable through __has_include (e.g. Compiler Explorer raw-URL includes).
+#define CSL_WF__INCLUDED
+
 #if not __cplusplus >= 202002L
 # error "csl/wf.hpp requires C++20"
 #endif

--- a/test/consumption/main.cpp
+++ b/test/consumption/main.cpp
@@ -1,5 +1,5 @@
 #include <csl/ag.hpp>
-#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/backend/std_format.hpp>
 #include <csl/ag/formatting/typeinfo.hpp>
 #include <csl/ensure.hpp>
 #include <csl/functional.hpp>

--- a/test/consumption/main.cpp
+++ b/test/consumption/main.cpp
@@ -7,6 +7,8 @@
 #include <csl/typeinfo.hpp>
 #include <csl/wf.hpp>
 
+#include <format>
+
 struct point { int x, y; };
 static_assert(csl::ag::size_v<point> == 2);
 
@@ -30,5 +32,5 @@ static_assert(csl::ag::io::type_name_v<int> == "int");
 
 auto main() -> int {
     using namespace csl::ag::io;
-    return to_string<typenamed>(point{ .x = 1, .y = 2 }) == "{int: 1, int: 2}" ? 0 : 1;
+    return std::format("{}", point{ .x = 1, .y = 2 } | typenamed) == "{int: 1, int: 2}" ? 0 : 1;
 }

--- a/test/consumption/main.cpp
+++ b/test/consumption/main.cpp
@@ -1,4 +1,6 @@
 #include <csl/ag.hpp>
+#include <csl/ag/formatting/format.hpp>
+#include <csl/ag/formatting/typeinfo.hpp>
 #include <csl/ensure.hpp>
 #include <csl/functional.hpp>
 #include <csl/mp.hpp>
@@ -23,4 +25,10 @@ static_assert(std::is_same_v<
 
 static_assert(csl::typeinfo::type_name_v<int> == "int");
 
-auto main() -> int {}
+// typeinfo bridge: csl::ag::io::type_name is csl::typeinfo-backed (compile-time)
+static_assert(csl::ag::io::type_name_v<int> == "int");
+
+auto main() -> int {
+    using namespace csl::ag::io;
+    return to_string<typenamed>(point{ .x = 1, .y = 2 }) == "{int: 1, int: 2}" ? 0 : 1;
+}


### PR DESCRIPTION
- [x] move opt-ins in dedicated files -> `csl/ag/formatting/backend/<backend>.hpp`
  - **Question**: for STL-related backends, `std_` prefix ?
- [x] fix possible ODRs
- [x] improve in-code documentation
- [x] remove `csl::ag::io::to_string`

---

## remove `to_string`

- inconsistent as-is (only supports std::format backend)
- confusing for users
- poor/low additional value

Alternative approach would be to prioritize overload resolution based on which backend is available, for when ostream and std::format are both available, the implementation of to_string which use `std::format` is prefered.

- 🔴 **Author call**: no.

  That would result in too many template instanciations, for low additional value.  
  Each backend should use its own idiom ... 😔

- 🟡 Alternative

  Use `priority_tag`, but this will result in costly overload-resolution + template instanciation.

### Current implementation is:

```cpp
/// \brief Formatting: to_string (std::format-backed)
///        Usage:
///
///         using namespace csl::ag::io;
///         to_string(value)                        (default: braced, compact)
///         to_string<indented>(value)              (single option)
///         to_string<indented | typenamed>(value)  (composed options)
///         to_string(value | indented | typenamed) (equivalent, view-based composition)
namespace csl::ag::io {

    template <format_options Options = format_options::none>
    [[nodiscard]] auto to_string(csl::ag::concepts::structured_bindable auto const & value) -> std::string
    requires (not details::concepts::decorator<std::remove_cvref_t<decltype(value)>>)
    {
        // NOTE: at default Options, format `value` directly so a user-defined formatter (if any) wins,
        // exactly as the plain (option-less) operator<< / formatter<T> specializations do.
        if constexpr (Options == format_options::none)
            return std::format("{}", value);
        else {
            using value_type = std::remove_cvref_t<decltype(value)>;
            return std::format("{}", details::decorators::formatted_view_t<value_type>{
                .value = value,
                .options = Options
            });
        }
    }
    template <typename T>
    [[nodiscard]] auto to_string(details::decorators::formatted_view_t<T> const & view) -> std::string {
        return std::format("{}", view);
    }
}
```
